### PR TITLE
Fix OAuth overlay default visibility

### DIFF
--- a/public/warehouse-hq.html
+++ b/public/warehouse-hq.html
@@ -648,6 +648,10 @@
       z-index: 40;
     }
 
+    .oauth-overlay[hidden] {
+      display: none !important;
+    }
+
     .oauth-dialog {
       display: flex;
       gap: 1rem;


### PR DESCRIPTION
## Summary
- ensure the OAuth overlay respects the hidden attribute by adding a scoped CSS rule

## Testing
- npm test -- --watch=false *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68d58a0f9f68832d9a71caabe33aa74e