### PR TITLE
Add Shopify sync support and audit logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ const { setStep, setField, get: getState } = require('./lib/leadStore');
 const { createUserRouter } = require('./routes/users');
 const createIntegrationsRouter = require('./routes/integrations');
 const createSupportRouter = require('./routes/support');
+const createShopifyRouter = require('./routes/shopify');
+const createAuditRouter = require('./routes/audit');
 
 const jwt = require('jsonwebtoken');
 
@@ -56,6 +58,8 @@ app.use(express.json());
 app.use('/api/users', createUserRouter());
 app.use('/api/integrations', createIntegrationsRouter());
 app.use('/api/support', createSupportRouter(openai));
+app.use('/api/shopify', createShopifyRouter());
+app.use('/api/audit', createAuditRouter());
 
 // 👉 Serve the landing page & assets from /public
 app.use(express.static(path.join(__dirname, 'public')));

--- a/lib/integrations.js
+++ b/lib/integrations.js
@@ -1,0 +1,35 @@
+const { getCollection, ObjectId } = require('../services/mongo');
+const { decryptString } = require('./crypto');
+
+function parseIntegrationCredentials(raw){
+  if (!raw) return {};
+  try {
+    const decoded = decryptString(raw);
+    if (!decoded) return {};
+    return JSON.parse(decoded);
+  } catch (err){
+    return {};
+  }
+}
+
+async function findIntegrationById(id, userId){
+  const col = await getCollection('integrations');
+  const filter = { _id: new ObjectId(id) };
+  if (userId){
+    filter.userId = userId;
+  }
+  const row = await col.findOne(filter);
+  return row || null;
+}
+
+async function findIntegrationByService(userId, serviceId){
+  const col = await getCollection('integrations');
+  const row = await col.findOne({ userId, serviceId });
+  return row || null;
+}
+
+module.exports = {
+  parseIntegrationCredentials,
+  findIntegrationById,
+  findIntegrationByService,
+};

--- a/public/warehouse-hq.html
+++ b/public/warehouse-hq.html
@@ -251,6 +251,32 @@
       color: var(--text-muted);
     }
 
+    .hint.warning {
+      color: var(--warning);
+      font-weight: 600;
+    }
+
+    .hint.success {
+      color: var(--success);
+      font-weight: 600;
+    }
+
+    .table-scroll.small {
+      max-height: 220px;
+      overflow-y: auto;
+      overflow-x: auto;
+    }
+
+    .shopify-warning {
+      margin-top: 0.5rem;
+      padding: 0.6rem 0.75rem;
+      border-radius: 0.75rem;
+      background: rgba(250, 204, 21, 0.08);
+      border: 1px solid rgba(250, 204, 21, 0.3);
+      color: var(--warning);
+      font-size: 0.8rem;
+    }
+
     button.cta {
       background: linear-gradient(135deg, #38bdf8, #2563eb);
       border: none;
@@ -909,8 +935,12 @@
 
         <div class="panel">
           <div class="flex-space">
-            <h3>Inventory Snapshot</h3>
-            <div class="flex">
+            <div>
+              <h3>Inventory Snapshot</h3>
+              <p class="hint" id="shopify-sync-status">Connect Shopify to sync your catalogue.</p>
+            </div>
+            <div class="flex" id="inventory-toolbar">
+              <button class="secondary" type="button" id="shopify-sync-btn">Sync Shopify</button>
               <input type="search" id="inventory-search" placeholder="Search SKU, name, lot…" />
               <select id="warehouse-filter"></select>
             </div>
@@ -931,6 +961,49 @@
               </thead>
               <tbody id="inventory-body"></tbody>
             </table>
+          </div>
+          <div id="shopify-warnings" class="shopify-warning" style="display:none;"></div>
+        </div>
+
+        <div class="grid grid-2">
+          <div class="panel light">
+            <div class="flex-space">
+              <h3>Shopify Collections</h3>
+              <span class="hint" id="collections-count">—</span>
+            </div>
+            <div class="table-scroll small">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Collection</th>
+                    <th>Type</th>
+                    <th>Products</th>
+                    <th>Updated</th>
+                  </tr>
+                </thead>
+                <tbody id="collections-body"></tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="panel light">
+            <div class="flex-space">
+              <h3>Gift Cards</h3>
+              <span class="hint" id="gift-cards-count">—</span>
+            </div>
+            <div class="table-scroll small">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Last 4</th>
+                    <th>Balance</th>
+                    <th>Customer</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody id="gift-cards-body"></tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>
@@ -1067,6 +1140,50 @@
             </label>
             <button class="cta" type="button" id="plan-cycle">Plan Cycle Count</button>
             <div class="callout" id="cycle-plan">Plan a cycle count to reduce stockouts by 22%.</div>
+          </div>
+        </div>
+
+        <div class="grid grid-2">
+          <div class="panel light">
+            <div class="flex-space">
+              <h3>Purchase Orders</h3>
+              <span class="hint" id="purchase-orders-count">—</span>
+            </div>
+            <div class="table-scroll small">
+              <table>
+                <thead>
+                  <tr>
+                    <th>PO</th>
+                    <th>Vendor</th>
+                    <th>Due</th>
+                    <th>Status</th>
+                    <th>Lines</th>
+                  </tr>
+                </thead>
+                <tbody id="purchase-orders-body"></tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="panel light">
+            <div class="flex-space">
+              <h3>Transfers</h3>
+              <span class="hint" id="transfers-count">—</span>
+            </div>
+            <div class="table-scroll small">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Transfer</th>
+                    <th>Route</th>
+                    <th>ETA</th>
+                    <th>Status</th>
+                    <th>Lines</th>
+                  </tr>
+                </thead>
+                <tbody id="transfers-body"></tbody>
+              </table>
+            </div>
           </div>
         </div>
 
@@ -1508,6 +1625,9 @@
     let integrationCatalog = [];
     let integrationRows = [];
     const chartInstances = {};
+    const SHOPIFY_SYNC_CACHE_MS = 5 * 60 * 1000;
+    const SHOPIFY_SERVICE_ID = 'shopify';
+    const shopifySyncState = { loading: false, lastAttempt: 0 };
     const BRAND_LOGO_MAX_LENGTH = 240000; // ~180KB payload cap for safe API uploads
     const MANUAL_FORM_HINT = 'Use this form for manual keys or fallback credentials. One-click providers finish automatically below.';
     const integrationFormHint = document.getElementById('integration-form-hint');
@@ -1523,6 +1643,12 @@
           if (!data.branding) {
             data.branding = seedState().branding;
           }
+          if (!Array.isArray(data.collections)) data.collections = [];
+          if (!Array.isArray(data.giftCards)) data.giftCards = [];
+          if (!Array.isArray(data.purchaseOrders)) data.purchaseOrders = [];
+          if (!Array.isArray(data.transfers)) data.transfers = [];
+          if (!Array.isArray(data.shopifyWarnings)) data.shopifyWarnings = [];
+          if (!('lastShopifySync' in data)) data.lastShopifySync = null;
           return data;
         }
       } catch (err) {
@@ -1571,6 +1697,12 @@
         receipts: [],
         shipments: [],
         returns: [],
+        collections: [],
+        purchaseOrders: [],
+        transfers: [],
+        giftCards: [],
+        shopifyWarnings: [],
+        lastShopifySync: null,
         tasks: [],
         gamification: [
           { id: crypto.randomUUID(), message: '🏅 Team Inbound earned "5-Star Receiver" for 99.6% accuracy this week.' },
@@ -1697,6 +1829,13 @@
       const date = new Date(dateStr);
       if (Number.isNaN(date.getTime())) return dateStr;
       return date.toLocaleDateString();
+    }
+
+    function formatDateTime(dateStr) {
+      if (!dateStr) return '—';
+      const date = new Date(dateStr);
+      if (Number.isNaN(date.getTime())) return dateStr;
+      return date.toLocaleString([], { dateStyle: 'short', timeStyle: 'short' });
     }
 
     function showToast(message) {
@@ -2004,6 +2143,248 @@
       priorities.innerHTML = missions.map(m => `<li>${m}</li>`).join('');
 
       renderCharts();
+    }
+
+    function renderCollections() {
+      const tbody = document.getElementById('collections-body');
+      const count = document.getElementById('collections-count');
+      if (!tbody) return;
+      const rows = Array.isArray(state.collections) ? state.collections : [];
+      if (count) {
+        count.textContent = rows.length ? `${rows.length} collections` : 'No collections';
+      }
+      if (!rows.length) {
+        tbody.innerHTML = '<tr><td colspan="4"><span class="hint">No collections synced yet.</span></td></tr>';
+        return;
+      }
+      tbody.innerHTML = rows.map(row => {
+        const type = row.type ? row.type.charAt(0).toUpperCase() + row.type.slice(1) : '—';
+        return `
+          <tr>
+            <td><strong>${row.title || 'Untitled'}</strong><br><span class="hint">${row.handle || ''}</span></td>
+            <td>${type}</td>
+            <td>${row.productsCount ?? '—'}</td>
+            <td>${row.updatedAt ? formatDate(row.updatedAt) : '—'}</td>
+          </tr>
+        `;
+      }).join('');
+    }
+
+    function renderGiftCards() {
+      const tbody = document.getElementById('gift-cards-body');
+      const count = document.getElementById('gift-cards-count');
+      if (!tbody) return;
+      const cards = Array.isArray(state.giftCards) ? state.giftCards : [];
+      if (count) {
+        count.textContent = cards.length ? `${cards.length} cards` : 'No gift cards';
+      }
+      if (!cards.length) {
+        tbody.innerHTML = '<tr><td colspan="4"><span class="hint">No gift cards available.</span></td></tr>';
+        return;
+      }
+      const now = Date.now();
+      tbody.innerHTML = cards.map(card => {
+        const balanceNum = Number(card.balance);
+        const balance = Number.isFinite(balanceNum) ? `$${balanceNum.toFixed(2)} ${card.currency || 'USD'}` : '—';
+        const expires = card.expiresOn ? new Date(card.expiresOn).getTime() : null;
+        let status = 'Active';
+        if (card.disabledAt) status = 'Disabled';
+        else if (expires && expires < now) status = 'Expired';
+        return `
+          <tr>
+            <td>${card.lastCharacters ? `•••• ${card.lastCharacters}` : '—'}<br><span class="hint">${card.createdAt ? formatDate(card.createdAt) : ''}</span></td>
+            <td>${balance}</td>
+            <td>${card.customerEmail || '—'}</td>
+            <td>${status}</td>
+          </tr>
+        `;
+      }).join('');
+    }
+
+    function renderPurchaseOrders() {
+      const tbody = document.getElementById('purchase-orders-body');
+      const count = document.getElementById('purchase-orders-count');
+      if (!tbody) return;
+      const orders = Array.isArray(state.purchaseOrders) ? state.purchaseOrders : [];
+      if (count) {
+        count.textContent = orders.length ? `${orders.length} POs` : 'No purchase orders';
+      }
+      if (!orders.length) {
+        tbody.innerHTML = '<tr><td colspan="5"><span class="hint">No purchase orders synced.</span></td></tr>';
+        return;
+      }
+      tbody.innerHTML = orders.map(order => `
+        <tr>
+          <td><strong>${order.name || 'PO'}</strong><br><span class="hint">${order.createdAt ? formatDate(order.createdAt) : ''}</span></td>
+          <td>${order.vendor || '—'}</td>
+          <td>${order.expectedAt ? formatDate(order.expectedAt) : '—'}</td>
+          <td>${order.status || '—'}</td>
+          <td>${order.lineCount ?? '—'}</td>
+        </tr>
+      `).join('');
+    }
+
+    function renderTransfers() {
+      const tbody = document.getElementById('transfers-body');
+      const count = document.getElementById('transfers-count');
+      if (!tbody) return;
+      const transfers = Array.isArray(state.transfers) ? state.transfers : [];
+      if (count) {
+        count.textContent = transfers.length ? `${transfers.length} transfers` : 'No transfers';
+      }
+      if (!transfers.length) {
+        tbody.innerHTML = '<tr><td colspan="5"><span class="hint">No transfers synced.</span></td></tr>';
+        return;
+      }
+      tbody.innerHTML = transfers.map(transfer => {
+        const route = [transfer.source, transfer.destination].filter(Boolean).join(' → ') || '—';
+        return `
+          <tr>
+            <td><strong>${transfer.reference || 'Transfer'}</strong><br><span class="hint">${transfer.createdAt ? formatDate(transfer.createdAt) : ''}</span></td>
+            <td>${route}</td>
+            <td>${transfer.expectedArrival ? formatDate(transfer.expectedArrival) : '—'}</td>
+            <td>${transfer.status || '—'}</td>
+            <td>${transfer.lineCount ?? '—'}</td>
+          </tr>
+        `;
+      }).join('');
+    }
+
+    function renderShopifyWarnings() {
+      const panel = document.getElementById('shopify-warnings');
+      if (!panel) return;
+      const warnings = Array.isArray(state.shopifyWarnings) ? state.shopifyWarnings.filter(Boolean) : [];
+      if (!warnings.length) {
+        panel.style.display = 'none';
+        panel.textContent = '';
+        return;
+      }
+      panel.innerHTML = warnings.map(w => `<div>${w}</div>`).join('');
+      panel.style.display = 'block';
+    }
+
+    function hasShopifyIntegration(){
+      return integrationRows.some(row => row.serviceId === SHOPIFY_SERVICE_ID && row.status !== 'oauth_pending');
+    }
+
+    function updateShopifySyncUi({ available, syncing = false } = {}){
+      const statusEl = document.getElementById('shopify-sync-status');
+      const btn = document.getElementById('shopify-sync-btn');
+      if (!statusEl || !btn) return;
+      if (!available){
+        btn.style.display = 'none';
+        btn.disabled = true;
+        statusEl.textContent = 'Connect Shopify to sync your catalogue.';
+        statusEl.classList.remove('success');
+        statusEl.classList.remove('warning');
+        return;
+      }
+      btn.style.display = 'inline-flex';
+      btn.disabled = !!syncing;
+      btn.textContent = syncing ? 'Syncing…' : 'Sync Shopify';
+      if (syncing){
+        statusEl.textContent = 'Sync in progress…';
+        statusEl.classList.remove('success');
+        statusEl.classList.remove('warning');
+        return;
+      }
+      if (state.lastShopifySync){
+        statusEl.textContent = `Synced ${formatDateTime(state.lastShopifySync)}`;
+        statusEl.classList.add('success');
+        statusEl.classList.remove('warning');
+      } else {
+        statusEl.textContent = 'Ready to pull live data from Shopify.';
+        statusEl.classList.remove('success');
+        statusEl.classList.remove('warning');
+      }
+    }
+
+    function applyShopifyData(payload){
+      const data = payload?.data || {};
+      const meta = payload?.meta || {};
+      const locations = Array.isArray(data.locations) ? data.locations : [];
+      const inventory = Array.isArray(data.inventory) ? data.inventory : [];
+      if (locations.length){
+        state.warehouses = locations.map(loc => ({
+          id: String(loc.id || crypto.randomUUID()),
+          name: loc.name || `Location ${loc.id}`,
+          type: loc.active ? 'Shopify Location' : 'Inactive Location',
+          capacity: 0,
+          notes: [loc.address1, loc.city, loc.country].filter(Boolean).join(', '),
+        }));
+      }
+      state.collections = Array.isArray(data.collections) ? data.collections : [];
+      state.giftCards = Array.isArray(data.giftCards) ? data.giftCards : [];
+      state.purchaseOrders = Array.isArray(data.purchaseOrders) ? data.purchaseOrders : [];
+      state.transfers = Array.isArray(data.transfers) ? data.transfers : [];
+      state.shopifyWarnings = Array.isArray(meta.warnings) ? meta.warnings : [];
+      state.lastShopifySync = payload?.fetchedAt || new Date().toISOString();
+      const inventoryRows = inventory.map(item => ({
+        sku: item.sku,
+        name: item.productTitle || item.sku,
+        variant: item.variantTitle || '',
+        category: item.productType || '',
+        warehouseId: item.locationId || '',
+        location: item.locationName || '',
+        quantity: Number(item.available) || 0,
+        reorder: Number(item.reorderPoint) || 0,
+        lot: '',
+        expiry: '',
+        unitCost: item.price != null ? Number(item.price) : 0,
+      }));
+      state.items = inventoryRows;
+      persist();
+      updateWarehouseSelects();
+      renderInventory();
+      renderCollections();
+      renderGiftCards();
+      renderPurchaseOrders();
+      renderTransfers();
+      renderShopifyWarnings();
+      renderStats();
+      updateShopifySyncUi({ available: true });
+    }
+
+    async function syncShopifyIfAvailable(force = false){
+      if (!isAuthenticated()) return;
+      const available = hasShopifyIntegration();
+      updateShopifySyncUi({ available, syncing: shopifySyncState.loading });
+      if (!available) return;
+      if (!force && state.lastShopifySync){
+        const last = new Date(state.lastShopifySync).getTime();
+        if (!Number.isNaN(last) && Date.now() - last < SHOPIFY_SYNC_CACHE_MS){
+          return;
+        }
+      }
+      if (shopifySyncState.loading) return;
+      shopifySyncState.loading = true;
+      shopifySyncState.lastAttempt = Date.now();
+      updateShopifySyncUi({ available, syncing: true });
+      try {
+        const res = await fetch('/api/shopify/sync', { headers: authHeaders() });
+        if (res.status === 401){
+          handleUnauthorized();
+          return;
+        }
+        const data = await res.json();
+        if (!res.ok){
+          throw new Error(data?.message || data?.error || 'Failed to sync Shopify');
+        }
+        applyShopifyData(data);
+        showToast('Shopify data synced.');
+      } catch (err){
+        console.error('Shopify sync failed', err);
+        const warning = err?.message || 'Sync failed.';
+        state.shopifyWarnings = state.shopifyWarnings || [];
+        if (!state.shopifyWarnings.includes(warning)){
+          state.shopifyWarnings.push(warning);
+        }
+        renderShopifyWarnings();
+        showToast('Shopify sync failed.');
+      } finally {
+        shopifySyncState.loading = false;
+        updateShopifySyncUi({ available, syncing: false });
+      }
     }
 
     function ensureChart(id, config){
@@ -2507,6 +2888,8 @@
       if (!authState.token){
         integrationRows = [];
         tbody.innerHTML = '<tr><td colspan="5" class="integration-table-empty">Sign in to manage integrations.</td></tr>';
+        updateShopifySyncUi({ available: false });
+        renderShopifyWarnings();
         return;
       }
       try {
@@ -2522,6 +2905,8 @@
         renderIntegrations(data.integrations || []);
       } catch (err){
         tbody.innerHTML = '<tr><td colspan="5" class="integration-table-empty">Unable to load integrations.</td></tr>';
+        updateShopifySyncUi({ available: hasShopifyIntegration() });
+        renderShopifyWarnings();
       }
     }
 
@@ -2531,6 +2916,8 @@
       integrationRows = rows;
       if (!rows.length){
         tbody.innerHTML = '<tr><td colspan="5" class="integration-table-empty">No integrations yet. Connect your first platform.</td></tr>';
+        updateShopifySyncUi({ available: false });
+        renderShopifyWarnings();
         return;
       }
       tbody.innerHTML = rows.map(row => {
@@ -2554,6 +2941,14 @@
       }).join('');
       tbody.querySelectorAll('button[data-action="delete"]').forEach(btn => btn.addEventListener('click', () => deleteIntegration(btn.dataset.id)));
       tbody.querySelectorAll('button[data-action="complete-oauth"]').forEach(btn => btn.addEventListener('click', () => completeOneClick(btn.dataset.id, { serviceId: btn.dataset.service, status: btn.dataset.status })));
+      const available = hasShopifyIntegration();
+      updateShopifySyncUi({ available, syncing: shopifySyncState.loading });
+      if (available) {
+        syncShopifyIfAvailable();
+      } else {
+        state.shopifyWarnings = [];
+        renderShopifyWarnings();
+      }
     }
 
     async function saveIntegration(evt){
@@ -3421,6 +3816,8 @@
       showToast('Tip: Create wave picks from the Orders tab to auto-assign teams.');
     });
 
+    document.getElementById('shopify-sync-btn').addEventListener('click', () => syncShopifyIfAvailable(true));
+
     document.getElementById('register-form').addEventListener('submit', registerAccount);
     document.getElementById('login-form').addEventListener('submit', loginAccount);
     document.getElementById('logout-btn').addEventListener('click', logoutAccount);
@@ -3435,6 +3832,11 @@
       renderShipments();
       renderReturns();
       renderTasks();
+      renderCollections();
+      renderGiftCards();
+      renderPurchaseOrders();
+      renderTransfers();
+      renderShopifyWarnings();
       renderStats();
       renderBundler();
     }

--- a/routes/audit.js
+++ b/routes/audit.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const { getAuditSummary } = require('../services/auditLog');
+
+const ADMIN_SECRET = process.env.ADMIN_AUDIT_SECRET || '';
+
+function createRouter(){
+  const router = express.Router();
+
+  router.get('/logs', async (req, res) => {
+    const provided = req.headers['x-admin-secret'] || req.query.secret || '';
+    if (!ADMIN_SECRET || provided !== ADMIN_SECRET){
+      return res.status(403).json({ error: 'forbidden' });
+    }
+    try {
+      const data = await getAuditSummary();
+      res.json({ ok: true, ...data });
+    } catch (err){
+      console.error('Audit log fetch error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createRouter;

--- a/routes/shopify.js
+++ b/routes/shopify.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const { authenticate } = require('./users');
+const { fetchShopifyData } = require('../services/shopify');
+const { findIntegrationByService, parseIntegrationCredentials } = require('../lib/integrations');
+const { recordAuditLog } = require('../services/auditLog');
+
+function resolveShopDomain(credentials = {}){
+  return (
+    credentials.shopDomain ||
+    credentials.shop ||
+    credentials.domain ||
+    credentials.storeDomain ||
+    process.env.SHOPIFY_SHOP_DOMAIN ||
+    ''
+  );
+}
+
+function resolveAccessToken(credentials = {}){
+  return (
+    credentials.accessToken ||
+    credentials.token ||
+    credentials.apiKey ||
+    ''
+  );
+}
+
+function createRouter(){
+  const router = express.Router();
+
+  router.use(authenticate);
+
+  router.get('/sync', async (req, res) => {
+    try {
+      const integration = await findIntegrationByService(req.user._id, 'shopify');
+      if (!integration){
+        return res.status(404).json({ error: 'shopify_not_connected' });
+      }
+      const credentials = parseIntegrationCredentials(integration.credentials);
+      const shop = resolveShopDomain(credentials);
+      const accessToken = resolveAccessToken(credentials);
+      if (!shop || !accessToken){
+        return res.status(400).json({ error: 'missing_shopify_credentials' });
+      }
+      const result = await fetchShopifyData({ shop, accessToken });
+      await recordAuditLog({
+        type: 'shopify_sync',
+        userId: req.user._id?.toString?.() || req.user._id,
+        integrationId: integration._id?.toString?.() || integration._id,
+        shop,
+        counts: result.meta?.counts || {},
+      });
+      res.json({
+        ok: true,
+        shop,
+        fetchedAt: result.fetchedAt,
+        data: result.data,
+        meta: result.meta,
+      });
+    } catch (err){
+      console.error('Shopify sync error', err);
+      const status = err?.status || 502;
+      res.status(status).json({ error: 'shopify_sync_failed', message: err?.message || 'Unable to sync Shopify' });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createRouter;

--- a/services/auditLog.js
+++ b/services/auditLog.js
@@ -1,0 +1,48 @@
+const { getCollection } = require('./mongo');
+
+async function recordAuditLog(entry = {}){
+  try {
+    const col = await getCollection('auditLogs');
+    if (!col) return;
+    const payload = {
+      ...entry,
+      createdAt: new Date().toISOString(),
+    };
+    await col.insertOne(payload);
+  } catch (err){
+    console.error('Audit log write failed', err);
+  }
+}
+
+async function getAuditSummary(limit = 200){
+  const col = await getCollection('auditLogs');
+  if (!col) return { summary: { total: 0, byType: {}, byUser: {}, metrics: {}, lastEvent: null }, logs: [] };
+  const cursor = await col.find({});
+  const rows = await cursor.toArray();
+  rows.sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0));
+  const limited = rows.slice(0, limit);
+  const summary = {
+    total: rows.length,
+    byType: {},
+    byUser: {},
+    metrics: {},
+    lastEvent: limited[0]?.createdAt || null,
+  };
+  limited.forEach(row => {
+    const type = row.type || 'unknown';
+    summary.byType[type] = (summary.byType[type] || 0) + 1;
+    const userId = row.userId || 'unknown';
+    summary.byUser[userId] = (summary.byUser[userId] || 0) + 1;
+    if (row.counts){
+      Object.entries(row.counts).forEach(([metric, value]) => {
+        summary.metrics[metric] = (summary.metrics[metric] || 0) + Number(value || 0);
+      });
+    }
+  });
+  return { summary, logs: limited };
+}
+
+module.exports = {
+  recordAuditLog,
+  getAuditSummary,
+};

--- a/services/shopify.js
+++ b/services/shopify.js
@@ -1,0 +1,272 @@
+const FETCH_LIMIT = Number(process.env.SHOPIFY_FETCH_LIMIT || 50);
+const API_VERSION = process.env.SHOPIFY_API_VERSION || '2024-04';
+
+function normalizeId(value){
+  if (value === null || value === undefined) return '';
+  try {
+    return String(value);
+  } catch (err){
+    return '';
+  }
+}
+
+async function shopifyRequest({ shop, accessToken, path, query = {} }){
+  if (!shop) {
+    throw new Error('Missing shop domain');
+  }
+  const url = new URL(`https://${shop}/admin/api/${API_VERSION}/${path}`);
+  Object.entries(query).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    if (Array.isArray(value)) {
+      if (value.length) url.searchParams.set(key, value.join(','));
+    } else {
+      url.searchParams.set(key, value);
+    }
+  });
+  const res = await fetch(url, {
+    headers: {
+      'X-Shopify-Access-Token': accessToken,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+  });
+  if (!res.ok){
+    const text = await res.text();
+    const err = new Error(`Shopify request failed (${res.status}) for ${path}`);
+    err.status = res.status;
+    err.body = text;
+    throw err;
+  }
+  return res.json();
+}
+
+async function safeCall(label, fn, meta){
+  try {
+    return await fn();
+  } catch (err){
+    const status = err?.status ? ` ${err.status}` : '';
+    const message = err?.message ? ` ${err.message}` : '';
+    const statusLabel = status ? ` Status:${status.trim()}` : '';
+    meta.warnings.push(`${label} unavailable.${statusLabel}${message}`.trim());
+    if (process.env.NODE_ENV !== 'test'){ // aid debugging without failing sync
+      console.warn(`Shopify ${label} fetch error`, err?.status, err?.message);
+    }
+    return [];
+  }
+}
+
+async function fetchLocations(opts, meta){
+  return safeCall('Locations', async () => {
+    const json = await shopifyRequest({ ...opts, path: 'locations.json', query: { limit: FETCH_LIMIT } });
+    const locations = Array.isArray(json.locations) ? json.locations : [];
+    return locations.map(loc => ({
+      id: normalizeId(loc.id),
+      name: loc.name,
+      active: !!loc.active,
+      address1: loc.address1 || '',
+      address2: loc.address2 || '',
+      city: loc.city || '',
+      province: loc.province || '',
+      zip: loc.zip || '',
+      country: loc.country || '',
+      phone: loc.phone || '',
+      legacy: !!loc.legacy,
+      createdAt: loc.created_at || null,
+      updatedAt: loc.updated_at || null,
+    }));
+  }, meta);
+}
+
+async function fetchProducts(opts, meta){
+  return safeCall('Products', async () => {
+    const query = {
+      limit: FETCH_LIMIT,
+      fields: 'id,title,handle,status,product_type,tags,created_at,updated_at,variants',
+    };
+    const json = await shopifyRequest({ ...opts, path: 'products.json', query });
+    return Array.isArray(json.products) ? json.products : [];
+  }, meta);
+}
+
+async function fetchCollections(opts, meta){
+  const segments = [];
+  const custom = await safeCall('Custom collections', async () => {
+    const json = await shopifyRequest({ ...opts, path: 'custom_collections.json', query: { limit: FETCH_LIMIT } });
+    return Array.isArray(json.custom_collections) ? json.custom_collections : [];
+  }, meta);
+  const smart = await safeCall('Smart collections', async () => {
+    const json = await shopifyRequest({ ...opts, path: 'smart_collections.json', query: { limit: FETCH_LIMIT } });
+    return Array.isArray(json.smart_collections) ? json.smart_collections : [];
+  }, meta);
+  segments.push(...custom, ...smart);
+  return segments.map(col => ({
+    id: normalizeId(col.id),
+    title: col.title,
+    handle: col.handle,
+    updatedAt: col.updated_at || col.published_at || null,
+    productsCount: Number(col.products_count || col.product_count || col.published_scope || 0) || 0,
+    type: col.rules ? 'smart' : 'custom',
+    sortOrder: col.sort_order || '',
+  }));
+}
+
+async function fetchInventory(opts, locations, products, meta){
+  const locationMap = new Map((locations || []).map(loc => [loc.id, loc]));
+  const variantMap = new Map();
+  (products || []).forEach(product => {
+    (product.variants || []).forEach(variant => {
+      const inventoryItemId = normalizeId(variant.inventory_item_id);
+      variantMap.set(inventoryItemId, {
+        sku: variant.sku || `VAR-${variant.id}`,
+        productId: normalizeId(product.id),
+        variantId: normalizeId(variant.id),
+        productTitle: product.title,
+        variantTitle: variant.title && variant.title !== product.title ? variant.title : '',
+        productType: product.product_type || '',
+        price: variant.price != null ? Number(variant.price) : null,
+        barcode: variant.barcode || '',
+        updatedAt: variant.updated_at || product.updated_at || product.created_at || null,
+      });
+    });
+  });
+
+  const allLevels = [];
+  for (const loc of locations || []){
+    const levels = await safeCall(`Inventory levels (${loc.name || loc.id})`, async () => {
+      const json = await shopifyRequest({
+        ...opts,
+        path: 'inventory_levels.json',
+        query: { limit: FETCH_LIMIT, location_ids: loc.id },
+      });
+      return Array.isArray(json.inventory_levels) ? json.inventory_levels : [];
+    }, meta);
+    allLevels.push(...levels);
+  }
+
+  return allLevels.map(level => {
+    const variant = variantMap.get(normalizeId(level.inventory_item_id)) || {};
+    const location = locationMap.get(normalizeId(level.location_id)) || {};
+    const available = Number(level.available);
+    return {
+      inventoryItemId: normalizeId(level.inventory_item_id),
+      locationId: normalizeId(level.location_id),
+      locationName: location.name || '',
+      available: Number.isFinite(available) ? available : 0,
+      updatedAt: level.updated_at || variant.updatedAt || null,
+      sku: variant.sku || `IID-${normalizeId(level.inventory_item_id)}`,
+      productTitle: variant.productTitle || variant.sku || 'SKU',
+      variantTitle: variant.variantTitle || '',
+      productType: variant.productType || '',
+      price: variant.price,
+      barcode: variant.barcode || '',
+      reorderPoint: available > 0 ? Math.max(1, Math.floor(available * 0.2)) : 0,
+    };
+  });
+}
+
+async function fetchPurchaseOrders(opts, meta){
+  return safeCall('Purchase orders', async () => {
+    const json = await shopifyRequest({ ...opts, path: 'purchase_orders.json', query: { limit: FETCH_LIMIT } });
+    const orders = Array.isArray(json.purchase_orders) ? json.purchase_orders : [];
+    return orders.map(order => ({
+      id: normalizeId(order.id),
+      name: order.name || order.po_number || `PO-${order.id}`,
+      status: order.status || 'open',
+      vendor: order.vendor || (order.supplier?.name ?? ''),
+      expectedAt: order.delivery_date || order.expected_delivery_date || null,
+      createdAt: order.created_at || null,
+      closedAt: order.closed_at || null,
+      lineCount: Array.isArray(order.line_items) ? order.line_items.length : Number(order.line_items_count) || 0,
+      totalQuantity: Array.isArray(order.line_items)
+        ? order.line_items.reduce((sum, item) => sum + (Number(item.quantity) || 0), 0)
+        : Number(order.total_quantity) || 0,
+    }));
+  }, meta);
+}
+
+async function fetchTransfers(opts, meta){
+  return safeCall('Transfers', async () => {
+    const json = await shopifyRequest({ ...opts, path: 'inventory_transfers.json', query: { limit: FETCH_LIMIT } });
+    const transfers = Array.isArray(json.inventory_transfers) ? json.inventory_transfers : [];
+    return transfers.map(transfer => ({
+      id: normalizeId(transfer.id),
+      reference: transfer.reference || transfer.name || `TR-${transfer.id}`,
+      status: transfer.status || 'open',
+      createdAt: transfer.created_at || null,
+      updatedAt: transfer.updated_at || null,
+      shippedAt: transfer.sent_at || null,
+      expectedArrival: transfer.expected_arrival_at || null,
+      receivedAt: transfer.received_at || null,
+      source: transfer.origin_address?.name || transfer.origin_address?.address1 || '',
+      destination: transfer.destination_address?.name || transfer.destination_address?.address1 || '',
+      lineCount: Array.isArray(transfer.line_items) ? transfer.line_items.length : Number(transfer.line_items_count) || 0,
+    }));
+  }, meta);
+}
+
+async function fetchGiftCards(opts, meta){
+  return safeCall('Gift cards', async () => {
+    const json = await shopifyRequest({ ...opts, path: 'gift_cards.json', query: { limit: FETCH_LIMIT } });
+    const cards = Array.isArray(json.gift_cards) ? json.gift_cards : [];
+    return cards.map(card => ({
+      id: normalizeId(card.id),
+      lastCharacters: card.last_characters || card.last_four_characters || '',
+      balance: Number(card.balance) || 0,
+      currency: card.currency || 'USD',
+      createdAt: card.created_at || null,
+      expiresOn: card.expires_on || null,
+      disabledAt: card.disabled_at || null,
+      customerEmail: card.customer ? (card.customer.email || '') : (card.customer_email || ''),
+      note: card.note || '',
+      templateSuffix: card.template_suffix || '',
+    }));
+  }, meta);
+}
+
+async function fetchShopifyData({ shop, accessToken }){
+  if (!shop) throw new Error('Missing Shopify shop domain');
+  if (!accessToken) throw new Error('Missing Shopify access token');
+
+  const meta = { warnings: [], counts: {} };
+  const opts = { shop, accessToken };
+  const fetchedAt = new Date().toISOString();
+
+  const [locations, products] = await Promise.all([
+    fetchLocations(opts, meta),
+    fetchProducts(opts, meta),
+  ]);
+
+  const [collections, inventory, purchaseOrders, transfers, giftCards] = await Promise.all([
+    fetchCollections(opts, meta),
+    fetchInventory(opts, locations, products, meta),
+    fetchPurchaseOrders(opts, meta),
+    fetchTransfers(opts, meta),
+    fetchGiftCards(opts, meta),
+  ]);
+
+  meta.counts = {
+    locations: locations.length,
+    collections: collections.length,
+    inventory: inventory.length,
+    purchaseOrders: purchaseOrders.length,
+    transfers: transfers.length,
+    giftCards: giftCards.length,
+  };
+
+  return {
+    fetchedAt,
+    data: {
+      locations,
+      collections,
+      inventory,
+      purchaseOrders,
+      transfers,
+      giftCards,
+    },
+    meta,
+  };
+}
+
+module.exports = {
+  fetchShopifyData,
+};


### PR DESCRIPTION
## Summary
- add Shopify service, routes, and integration helpers to securely pull collections, inventory, orders, transfers, and gift cards
- extend the Warehouse HQ UI to sync Shopify data into inventory, purchase orders, transfers, and gift card views with manual refresh and status messaging
- capture usage counts via a new audit log service and expose an admin-only endpoint for secure visibility

## Testing
- node index.js *(fails: missing Stripe credentials in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d593692308832d89e9dab44a219a11