### PR TITLE
Add env fallback for Shopify access token

### DIFF
--- a/routes/shopify.js
+++ b/routes/shopify.js
@@ -28,13 +28,23 @@ function resolveShopDomain(credentials = {}){
 }
 
 function resolveAccessToken(credentials = {}){
-  const token = (
-    credentials.accessToken ||
-    credentials.token ||
-    credentials.apiKey ||
-    ''
-  );
-  return typeof token === 'string' ? token.trim() : '';
+  const sources = [
+    credentials.accessToken,
+    credentials.token,
+    credentials.apiKey,
+    process.env.SHOPIFY_ADMIN_ACCESS_TOKEN,
+    process.env.SHOPIFY_ACCESS_TOKEN,
+    process.env.SHOPIFY_API_TOKEN,
+    process.env.SHOPIFY_API_KEY,
+  ];
+
+  for (const value of sources){
+    if (typeof value === 'string' && value.trim()){
+      return value.trim();
+    }
+  }
+
+  return '';
 }
 
 function createRouter(){


### PR DESCRIPTION
## Summary
- allow the Shopify sync route to read access tokens from common environment variables when integration credentials are empty

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5b21e55f0832d81a6998b4fb0c66e