### PR TITLE
Fix demo bootstrap credential drift

### DIFF
--- a/lib/bootstrapDemo.js
+++ b/lib/bootstrapDemo.js
@@ -1,6 +1,6 @@
 const { getCollection } = require('../services/mongo');
-const { hashPassword } = require('./security');
-const { encryptString } = require('./crypto');
+const { hashPassword, verifyPassword } = require('./security');
+const { encryptString, decryptString } = require('./crypto');
 
 const DEFAULT_EMAIL = process.env.DEMO_USER_EMAIL || 'captain@warehouse-hq.com';
 const DEFAULT_PASSWORD = process.env.DEMO_USER_PASSWORD || 'warehouse-demo';
@@ -15,6 +15,14 @@ async function ensureDemoUser(){
   const email = DEFAULT_EMAIL.toLowerCase();
   const existing = await users.findOne({ email });
   if (existing){
+    const updates = {};
+    if (!verifyPassword(DEFAULT_PASSWORD, existing.password || '')){
+      updates.password = hashPassword(DEFAULT_PASSWORD);
+    }
+    if (Object.keys(updates).length){
+      await users.updateOne({ _id: existing._id }, { $set: updates });
+      return { ...existing, ...updates };
+    }
     return existing;
   }
   const now = new Date().toISOString();
@@ -40,6 +48,35 @@ async function ensureDemoShopifyIntegration(user){
   const integrations = await getCollection('integrations');
   const existing = await integrations.findOne({ userId: user._id, serviceId: 'shopify' });
   if (existing){
+    const now = new Date().toISOString();
+    let credentials = {};
+    if (existing.credentials && typeof existing.credentials === 'object'){
+      credentials = existing.credentials;
+    } else {
+      try {
+        credentials = JSON.parse(decryptString(existing.credentials) || '{}');
+      } catch (err){
+        credentials = {};
+      }
+    }
+
+    const desired = {
+      shopDomain: DEFAULT_SHOP_DOMAIN,
+      accessToken: DEFAULT_SHOP_TOKEN,
+    };
+
+    const updates = {};
+    if (credentials.shopDomain !== desired.shopDomain || credentials.accessToken !== desired.accessToken){
+      updates.credentials = encryptString(desired);
+    }
+    if (existing.status !== 'demo_seeded'){
+      updates.status = 'demo_seeded';
+    }
+    if (Object.keys(updates).length){
+      updates.updatedAt = now;
+      await integrations.updateOne({ _id: existing._id }, { $set: updates });
+      return { ...existing, ...updates };
+    }
     return existing;
   }
   const now = new Date().toISOString();
@@ -51,7 +88,7 @@ async function ensureDemoShopifyIntegration(user){
     userId: user._id,
     serviceId: 'shopify',
     label: 'Warehouse Shopify',
-    credentials: encryptString(JSON.stringify(credentials)),
+    credentials: encryptString(credentials),
     notes: 'Demo Shopify workspace seeded by Warehouse HQ.',
     status: 'demo_seeded',
     connectedAt: now,


### PR DESCRIPTION
## Summary
- refresh the demo user password whenever the configured default changes
- resync stored Shopify demo credentials and status so demo sync can proceed

## Testing
- node -e "require('./lib/bootstrapDemo').bootstrapDemoData().then(res => { console.log('bootstrap result', res); process.exit(0); }).catch(err => { console.error(err); process.exit(1); });"

------
https://chatgpt.com/codex/tasks/task_e_68d60a95ba3c832d969f5d191dc383a2