### PR TITLE
Add persistent login sessions to Warehouse HQ

### DIFF
--- a/public/warehouse-hq.html
+++ b/public/warehouse-hq.html
@@ -3018,6 +3018,7 @@
       updateAccountStatus();
       renderTotpUi();
       loadIntegrations();
+      restoreSessionFromServer();
       if (wasAuthenticated){
         showToast(message);
       }
@@ -3038,12 +3039,39 @@
       renderTotpUi();
     }
 
+    async function restoreSessionFromServer(){
+      if (authState.token && authState.user) return;
+      try {
+        const res = await fetch('/api/users/session', { credentials: 'include' });
+        if (res.status === 204){
+          return;
+        }
+        if (!res.ok){
+          return;
+        }
+        const data = await res.json();
+        if (data && data.token && data.user){
+          setAuthState({ token: data.token, user: data.user });
+        }
+      } catch (err){
+        console.warn('Session restore skipped', err);
+      }
+    }
+
     async function hydrateAuth(){
       if (!authState.token || (authState.user && authState.user.email)) return;
       try {
-        const res = await fetch('/api/users/me', { headers: authHeaders() });
+        const res = await fetch('/api/users/me', { headers: authHeaders(), credentials: 'include' });
+        if (res.status === 401){
+          handleUnauthorized();
+          await restoreSessionFromServer();
+          return;
+        }
+        if (!res.ok){
+          return;
+        }
         const data = await res.json();
-        if (res.ok && data.user){
+        if (data && data.user){
           setAuthState({ token: authState.token, user: data.user });
         }
       } catch (err){
@@ -3201,6 +3229,7 @@
         const res = await fetch('/api/users/register', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
           body: JSON.stringify(payload),
         });
         const data = await res.json();
@@ -3225,6 +3254,7 @@
         const res = await fetch('/api/users/login', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
           body: JSON.stringify(payload),
         });
         const data = await res.json();
@@ -3241,7 +3271,16 @@
       }
     }
 
-    function logoutAccount(){
+    async function logoutAccount(){
+      try {
+        await fetch('/api/users/logout', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeaders() },
+          credentials: 'include',
+        });
+      } catch (err){
+        console.warn('Logout request failed', err);
+      }
       authState = { token: null, user: null };
       persistAuth();
       updateAccountStatus();
@@ -3255,6 +3294,7 @@
         const res = await fetch('/api/users/totp/enable', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', ...authHeaders() },
+          credentials: 'include',
           body: JSON.stringify({ label: authState.user?.email || 'Warehouse HQ' }),
         });
         if (res.status === 401){
@@ -3279,6 +3319,7 @@
         const res = await fetch('/api/users/totp/disable', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', ...authHeaders() },
+          credentials: 'include',
         });
         if (res.status === 401){
           handleUnauthorized();
@@ -3670,6 +3711,7 @@
         const res = await fetch('/api/users/brand', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', ...authHeaders() },
+          credentials: 'include',
           body: JSON.stringify({ brandTheme }),
         });
         if (res.status === 401){
@@ -4499,7 +4541,10 @@
     fetchIntegrationCatalog();
     loadIntegrations();
     loadOperationsGallery();
-    hydrateAuth();
+    (async () => {
+      await restoreSessionFromServer();
+      await hydrateAuth();
+    })();
 
     handleNavigation();
     initializeUI();

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const express = require('express');
 const jwt = require('jsonwebtoken');
 const { getCollection, ObjectId } = require('../services/mongo');
@@ -5,7 +6,152 @@ const { encryptString, decryptString } = require('../lib/crypto');
 const { hashPassword, verifyPassword, generateTotpSecret, verifyTotp } = require('../lib/security');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'warehouse-hq-secret';
+const SESSION_COOKIE = process.env.SESSION_COOKIE_NAME || 'whq_session';
+const SESSION_TTL_MS = Number(process.env.SESSION_TTL_MS || 1000 * 60 * 60 * 24 * 30);
+const SESSION_SAME_SITE = process.env.SESSION_SAMESITE || 'Lax';
+const SESSION_SECURE = String(process.env.SESSION_COOKIE_SECURE || '').toLowerCase() === 'true';
 
+function cookieShouldBeSecure(){
+  if (SESSION_SECURE) return true;
+  const env = String(process.env.NODE_ENV || '').toLowerCase();
+  return env === 'production';
+}
+
+function parseCookies(header = ''){
+  if (!header) return {};
+  return header.split(';').reduce((acc, part) => {
+    const [name, ...rest] = part.trim().split('=');
+    if (!name) return acc;
+    const value = rest.join('=');
+    acc[name] = decodeURIComponent(value || '');
+    return acc;
+  }, {});
+}
+
+function getSessionTokenFromRequest(req){
+  const cookies = parseCookies(req.headers?.cookie || '');
+  const token = cookies[SESSION_COOKIE];
+  return token ? token : null;
+}
+
+function formatCookieValue(value, maxAgeSeconds){
+  const parts = [`${SESSION_COOKIE}=${value}`];
+  if (typeof maxAgeSeconds === 'number'){
+    parts.push(`Max-Age=${Math.max(0, Math.floor(maxAgeSeconds))}`);
+  }
+  parts.push('Path=/');
+  parts.push('HttpOnly');
+  parts.push(`SameSite=${SESSION_SAME_SITE}`);
+  if (cookieShouldBeSecure()) parts.push('Secure');
+  return parts.join('; ');
+}
+
+function setSessionCookie(res, token){
+  const encoded = encodeURIComponent(token);
+  res.setHeader('Set-Cookie', formatCookieValue(encoded, SESSION_TTL_MS / 1000));
+}
+
+function clearSessionCookie(res){
+  res.setHeader('Set-Cookie', formatCookieValue('', 0));
+}
+
+function hashSessionToken(token){
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+function generateSessionToken(){
+  return crypto.randomBytes(48)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function clientIp(req){
+  const forwarded = req.headers?.['x-forwarded-for'];
+  if (forwarded){
+    return forwarded.split(',')[0].trim();
+  }
+  return req.socket?.remoteAddress || '';
+}
+
+async function createSession(user, req){
+  const sessions = await getCollection('sessions');
+  const token = generateSessionToken();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const doc = {
+    _id: tokenHash,
+    tokenHash,
+    userId: user._id,
+    createdAt: now.toISOString(),
+    lastSeenAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + SESSION_TTL_MS).toISOString(),
+    userAgent: req.headers?.['user-agent'] || '',
+    ip: clientIp(req),
+  };
+  await sessions.insertOne(doc);
+  return { token, doc };
+}
+
+async function deleteSessionByToken(token){
+  if (!token) return;
+  const sessions = await getCollection('sessions');
+  await sessions.deleteOne({ _id: hashSessionToken(token) });
+}
+
+async function findSessionByToken(token){
+  if (!token) return null;
+  const sessions = await getCollection('sessions');
+  const tokenHash = hashSessionToken(token);
+  const session = await sessions.findOne({ _id: tokenHash });
+  if (!session) return null;
+  if (session.expiresAt && new Date(session.expiresAt).getTime() < Date.now()){
+    await sessions.deleteOne({ _id: tokenHash });
+    return null;
+  }
+  return session;
+}
+
+async function refreshSession(session){
+  try {
+    const sessions = await getCollection('sessions');
+    const now = new Date();
+    const updates = {
+      lastSeenAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + SESSION_TTL_MS).toISOString(),
+    };
+    await sessions.updateOne({ _id: session._id || session.tokenHash }, { $set: updates });
+  } catch (err){
+    console.error('Session refresh failed', err);
+  }
+}
+
+function normalizeUserIdForQuery(userId){
+  if (!userId) return userId;
+  if (typeof userId === 'string' || typeof userId === 'number'){
+    try {
+      return new ObjectId(userId);
+    } catch (err){
+      return userId;
+    }
+  }
+  return userId;
+}
+
+async function attachSession(res, user, req){
+  try {
+    const existingToken = getSessionTokenFromRequest(req);
+    if (existingToken){
+      await deleteSessionByToken(existingToken);
+    }
+    const { token } = await createSession(user, req);
+    setSessionCookie(res, token);
+  } catch (err){
+    console.error('Session create failed', err);
+    clearSessionCookie(res);
+  }
+}
 function sanitizeUser(user){
   if (!user) return null;
   return {
@@ -86,6 +232,7 @@ function createRouter(){
       const result = await users.insertOne(doc);
       const savedUser = { ...doc, _id: result.insertedId };
       const token = createToken(savedUser);
+      await attachSession(res, savedUser, req);
       res.json({ ok: true, token, user: sanitizeUser(savedUser), totp: totpProvisioning });
     } catch (err){
       console.error('Register error', err);
@@ -120,9 +267,53 @@ function createRouter(){
         }
       }
       const token = createToken(user);
+      await attachSession(res, user, req);
       res.json({ ok: true, token, user: sanitizeUser(user) });
     } catch (err){
       console.error('Login error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  router.get('/session', async (req, res) => {
+    try {
+      const sessionToken = getSessionTokenFromRequest(req);
+      if (!sessionToken){
+        clearSessionCookie(res);
+        return res.status(204).end();
+      }
+      const session = await findSessionByToken(sessionToken);
+      if (!session){
+        clearSessionCookie(res);
+        return res.status(204).end();
+      }
+      const users = await getCollection('users');
+      const user = await users.findOne({ _id: normalizeUserIdForQuery(session.userId) });
+      if (!user){
+        await deleteSessionByToken(sessionToken);
+        clearSessionCookie(res);
+        return res.status(204).end();
+      }
+      await refreshSession(session);
+      setSessionCookie(res, sessionToken);
+      const token = createToken(user);
+      res.json({ ok: true, token, user: sanitizeUser(user) });
+    } catch (err){
+      console.error('Session lookup error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  router.post('/logout', async (req, res) => {
+    try {
+      const sessionToken = getSessionTokenFromRequest(req);
+      if (sessionToken){
+        await deleteSessionByToken(sessionToken);
+      }
+      clearSessionCookie(res);
+      res.json({ ok: true });
+    } catch (err){
+      console.error('Logout error', err);
       res.status(500).json({ error: 'server_error' });
     }
   });


### PR DESCRIPTION
## Summary
- add cookie-backed session storage helpers and session/login/logout endpoints so credentials persist between visits
- update the Warehouse HQ front-end authentication flow to use the new session API, include credentials on auth calls, and automatically restore saved sessions

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d6da427ae0832d8478d72ad42c85fd