### PR TITLE
Add inline scanner modal to key warehouse workflows

### DIFF
--- a/public/warehouse-hq.html
+++ b/public/warehouse-hq.html
@@ -1245,6 +1245,188 @@
       background: #0f1430;
     }
 
+    .scan-trigger {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-weight: 600;
+    }
+
+    .scan-trigger::before {
+      content: "📷";
+      font-size: 0.95rem;
+    }
+
+    body.scan-modal-open {
+      overflow: hidden;
+    }
+
+    .section-scan-modal {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      z-index: 90;
+    }
+
+    .section-scan-modal[hidden] {
+      display: none;
+    }
+
+    .section-scan-modal .scan-modal-backdrop {
+      position: absolute;
+      inset: 0;
+      background: rgba(2, 6, 23, 0.72);
+      backdrop-filter: blur(14px);
+    }
+
+    .section-scan-modal .scan-modal-content {
+      position: relative;
+      z-index: 1;
+      width: min(420px, 100%);
+      background: rgba(15, 23, 42, 0.95);
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      border-radius: 1.2rem;
+      padding: 1.5rem;
+      box-shadow: 0 30px 60px rgba(2, 6, 23, 0.45);
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .scan-modal-content h3 {
+      margin: 0;
+    }
+
+    .scan-modal-content p {
+      margin: 0;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+
+    .scan-modal-close {
+      position: absolute;
+      top: 0.75rem;
+      right: 0.75rem;
+      border: none;
+      background: transparent;
+      color: var(--text-muted);
+      font-size: 1.2rem;
+      cursor: pointer;
+    }
+
+    .scan-modal-stage {
+      position: relative;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      border-radius: 1rem;
+      overflow: hidden;
+      background: #000;
+      aspect-ratio: 3 / 4;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .scan-modal-stage video {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      transform: scaleX(-1);
+      background: #000;
+    }
+
+    .scan-modal-line {
+      position: absolute;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, #18e7a6, transparent);
+      box-shadow: 0 0 16px #18e7a6;
+      display: none;
+    }
+
+    .scan-modal-line.animate {
+      display: block;
+      animation: scan 2.2s ease-in-out infinite;
+    }
+
+    .scan-modal-hint {
+      position: absolute;
+      bottom: 1rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: rgba(2, 6, 23, 0.7);
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+    }
+
+    .scan-modal-input {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+
+    .scan-modal-input input {
+      padding: 0.65rem 0.85rem;
+      border-radius: 0.85rem;
+      border: 1px solid var(--border);
+      background: rgba(15, 23, 42, 0.78);
+      color: inherit;
+      font-size: 1rem;
+    }
+
+    .scan-modal-input input:focus {
+      outline: 2px solid rgba(56, 189, 248, 0.6);
+      outline-offset: 2px;
+    }
+
+    .scan-modal-buttons,
+    .scan-modal-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .scan-modal-actions button {
+      flex: 1;
+      min-width: 120px;
+    }
+
+    .scan-modal-status {
+      min-height: 1.1rem;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+
+    .scan-modal-status[data-variant="success"] {
+      color: var(--success);
+    }
+
+    .scan-modal-status[data-variant="error"] {
+      color: var(--danger);
+    }
+
+    .scan-modal-status[data-variant="info"] {
+      color: var(--text-muted);
+    }
+
+    @media (max-width: 600px) {
+      .scan-modal-content {
+        padding: 1.25rem;
+      }
+
+      .scan-modal-stage {
+        aspect-ratio: auto;
+        height: 240px;
+      }
+    }
+
     @media (prefers-reduced-motion: reduce) {
       .pallet.run,
       .wh-ghost.animate,
@@ -1526,6 +1708,7 @@
                 <input type="file" id="shopify-csv-input" accept=".csv,text/csv" multiple />
               </label>
               <button class="toolbar" type="button" id="print-stickers-btn">🖨 Print Stickers</button>
+              <button class="toolbar scan-trigger" type="button" data-scan-target="inventory">Quick Scan</button>
               <input type="search" id="inventory-search" placeholder="Search SKU, name, lot…" />
               <select id="warehouse-filter"></select>
               <select id="inventory-sort" aria-label="Sort inventory">
@@ -1651,6 +1834,7 @@
           <div class="flex-space">
             <h3>Open Orders</h3>
             <div class="flex">
+              <button class="secondary scan-trigger" type="button" data-scan-target="orders">Quick Scan</button>
               <select id="order-status-filter">
                 <option value="all">All</option>
                 <option value="open">Open</option>
@@ -1780,7 +1964,10 @@
         </div>
 
         <div class="panel">
-          <h3>Inbound Activity Log</h3>
+          <div class="flex-space">
+            <h3>Inbound Activity Log</h3>
+            <button class="secondary scan-trigger" type="button" data-scan-target="receipts">Quick Scan</button>
+          </div>
           <div class="table-scroll">
             <table>
               <thead>
@@ -1903,7 +2090,10 @@
 
         <div class="grid grid-2">
           <div class="panel">
-            <h3>Shipments</h3>
+            <div class="flex-space">
+              <h3>Shipments</h3>
+              <button class="secondary scan-trigger" type="button" data-scan-target="shipments">Quick Scan</button>
+            </div>
             <div class="table-scroll">
               <table>
                 <thead>
@@ -1921,7 +2111,10 @@
             </div>
           </div>
           <div class="panel">
-            <h3>Returns</h3>
+            <div class="flex-space">
+              <h3>Returns</h3>
+              <button class="secondary scan-trigger" type="button" data-scan-target="returns">Quick Scan</button>
+            </div>
             <div class="table-scroll">
               <table>
                 <thead>
@@ -2229,6 +2422,33 @@
       <small>Warehouse HQ is a free-to-use command center. Export your data anytime, integrate with your existing tech stack, and upgrade only when you&apos;re ready for more automation.</small>
     </div>
   </footer>
+
+  <div class="section-scan-modal" id="section-scan-modal" hidden aria-hidden="true">
+    <div class="scan-modal-backdrop" data-action="close"></div>
+    <div class="scan-modal-content" role="dialog" aria-modal="true" aria-labelledby="scan-modal-title" aria-describedby="scan-modal-description">
+      <button class="scan-modal-close" type="button" data-action="close" aria-label="Close scanner">✕</button>
+      <h3 id="scan-modal-title">Quick Scan</h3>
+      <p id="scan-modal-description">Focus the field below or start the camera to capture stickers without leaving your workflow.</p>
+      <div class="scan-modal-stage">
+        <video id="sectionScanVideo" playsinline muted></video>
+        <div class="scan-modal-line" id="sectionScanLine"></div>
+        <span class="scan-modal-hint">Align barcode with frame</span>
+      </div>
+      <label class="scan-modal-input" for="section-scan-input">
+        <span>Scan or type code</span>
+        <input id="section-scan-input" type="text" placeholder="Focus here and scan barcode" autocomplete="off" inputmode="text" />
+      </label>
+      <div class="scan-modal-buttons">
+        <button type="button" class="cta" id="scan-submit">Add to list</button>
+        <button type="button" class="secondary" data-action="close">Done</button>
+      </div>
+      <div class="scan-modal-actions">
+        <button type="button" class="secondary" id="scan-start-camera">Start camera</button>
+        <button type="button" class="secondary" id="scan-fake">Fake scan</button>
+      </div>
+      <div class="scan-modal-status" id="scan-modal-status"></div>
+    </div>
+  </div>
 
   <div class="toast" id="toast"></div>
   <div class="oauth-overlay" id="oauth-overlay" hidden aria-hidden="true">
@@ -5484,6 +5704,330 @@
           scanLine?.classList.remove('animate');
           alert('✓ Code recognized → Item received');
         }, 1600);
+      });
+    })();
+
+    (function initSectionScanner() {
+      const modal = document.getElementById('section-scan-modal');
+      if (!modal) return;
+
+      const titleEl = document.getElementById('scan-modal-title');
+      const descriptionEl = document.getElementById('scan-modal-description');
+      const inputEl = document.getElementById('section-scan-input');
+      const statusEl = document.getElementById('scan-modal-status');
+      const submitBtn = document.getElementById('scan-submit');
+      const startCameraBtn = document.getElementById('scan-start-camera');
+      const fakeBtn = document.getElementById('scan-fake');
+      const videoEl = document.getElementById('sectionScanVideo');
+      const lineEl = document.getElementById('sectionScanLine');
+      const triggers = Array.from(document.querySelectorAll('[data-scan-target]'));
+      const closeButtons = Array.from(modal.querySelectorAll('[data-action="close"]'));
+      const defaultPlaceholder = inputEl ? inputEl.placeholder : '';
+
+      let currentContext = null;
+      let activeStream = null;
+
+      const contexts = {
+        inventory: {
+          title: 'Scan SKU into Inventory',
+          description: 'Add or increment SKUs without leaving the catalogue.',
+          placeholder: 'Scan SKU barcode',
+          handler(code) {
+            const normalized = code.toUpperCase();
+            const item = findOrCreateItem({ sku: normalized });
+            if (!item.name || item.name === item.sku) {
+              item.name = normalized;
+            }
+            item.quantity = (Number(item.quantity) || 0) + 1;
+            persist();
+            renderInventory();
+            renderStats();
+            return { message: `Inventory updated for ${normalized}.`, toast: true };
+          }
+        },
+        orders: {
+          title: 'Scan Order for Fulfillment',
+          description: 'Drop orders into the live queue straight from the floor.',
+          placeholder: 'Scan order ID',
+          handler(code) {
+            const orderId = code.toUpperCase();
+            const existing = state.orders.find(order => String(order.orderId || '').toLowerCase() === orderId.toLowerCase());
+            let message;
+            if (existing) {
+              existing.status = existing.status && existing.status !== 'cancelled' ? existing.status : 'open';
+              existing.progress = Math.min(100, (Number(existing.progress) || 0) + 10);
+              if (!Array.isArray(existing.lines) || !existing.lines.length) {
+                existing.lines = [{ sku: orderId, qty: 1 }];
+              }
+              message = `Order ${orderId} updated from scan.`;
+            } else {
+              const warehouseId = state.warehouses[0]?.id || '';
+              const dueDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+              state.orders.push({
+                id: crypto.randomUUID(),
+                orderId,
+                customer: 'Quick scan',
+                warehouseId,
+                dueDate,
+                priority: 'Standard',
+                shipping: 'Standard',
+                lines: [{ sku: orderId, qty: 1 }],
+                status: 'open',
+                progress: 10,
+                createdAt: new Date().toISOString()
+              });
+              message = `Order ${orderId} created from scan.`;
+            }
+            persist();
+            renderOrders();
+            renderStats();
+            return { message, toast: true };
+          }
+        },
+        receipts: {
+          title: 'Scan Inbound Item',
+          description: 'Log received inventory and boost stock counts instantly.',
+          placeholder: 'Scan inbound SKU',
+          handler(code) {
+            const sku = code.toUpperCase();
+            const item = findOrCreateItem({ sku });
+            item.quantity = (Number(item.quantity) || 0) + 1;
+            const receipt = {
+              id: crypto.randomUUID(),
+              reference: `SCAN-${sku}`,
+              supplier: 'Quick scan',
+              warehouseId: item.warehouseId || state.warehouses[0]?.id || '',
+              sku,
+              quantity: 1,
+              location: item.location || '',
+              lot: item.lot || '',
+              expiry: item.expiry || '',
+              notes: 'Captured via quick scan',
+              date: new Date().toISOString()
+            };
+            state.receipts.push(receipt);
+            persist();
+            renderReceipts();
+            renderInventory();
+            renderStats();
+            return { message: `Inbound logged for ${sku}.`, toast: true };
+          }
+        },
+        shipments: {
+          title: 'Scan Shipment to Close',
+          description: 'Confirm a shipment right from the packing station.',
+          placeholder: 'Scan outbound order ID',
+          handler(code) {
+            const orderId = code.toUpperCase();
+            const shipment = {
+              id: crypto.randomUUID(),
+              orderId,
+              carrier: 'Quick scan',
+              tracking: `SCAN-${Math.random().toString(36).slice(2, 10).toUpperCase()}`,
+              packages: 1,
+              cost: 0,
+              date: new Date().toISOString()
+            };
+            state.shipments.push(shipment);
+            const order = state.orders.find(o => String(o.orderId || '').toLowerCase() === orderId.toLowerCase());
+            if (order) {
+              order.status = 'shipped';
+              order.progress = 100;
+            }
+            persist();
+            renderShipments();
+            renderOrders();
+            renderStats();
+            return { message: `Shipment captured for ${orderId}.`, toast: true };
+          }
+        },
+        returns: {
+          title: 'Scan Return to Process',
+          description: 'Capture a return and restock eligible items automatically.',
+          placeholder: 'Scan return SKU or order',
+          handler(code) {
+            const sku = code.toUpperCase();
+            const ret = {
+              id: crypto.randomUUID(),
+              orderId: sku,
+              sku,
+              quantity: 1,
+              reason: 'damaged',
+              disposition: 'restock',
+              date: new Date().toISOString()
+            };
+            state.returns.push(ret);
+            const item = findOrCreateItem({ sku });
+            item.quantity = (Number(item.quantity) || 0) + 1;
+            persist();
+            renderReturns();
+            renderInventory();
+            renderStats();
+            return { message: `Return logged for ${sku}.`, toast: true };
+          }
+        }
+      };
+
+      function setStatus(message = '', variant = 'info') {
+        if (!statusEl) return;
+        statusEl.textContent = message;
+        if (message) {
+          statusEl.dataset.variant = variant;
+          if (variant === 'error') {
+            statusEl.setAttribute('role', 'alert');
+          } else if (variant === 'success') {
+            statusEl.setAttribute('role', 'status');
+          } else {
+            statusEl.setAttribute('role', 'status');
+          }
+        } else {
+          statusEl.removeAttribute('data-variant');
+          statusEl.removeAttribute('role');
+        }
+      }
+
+      function stopCamera() {
+        if (activeStream) {
+          activeStream.getTracks().forEach(track => track.stop());
+          activeStream = null;
+        }
+        if (videoEl) {
+          videoEl.srcObject = null;
+        }
+        lineEl?.classList.remove('animate');
+      }
+
+      async function startCamera() {
+        if (!modal || modal.hidden) return;
+        if (!navigator.mediaDevices?.getUserMedia) {
+          setStatus('Camera not supported. Use a handheld barcode scanner instead.', 'error');
+          return;
+        }
+        try {
+          stopCamera();
+          const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' }, audio: false });
+          activeStream = stream;
+          if (videoEl) {
+            videoEl.srcObject = stream;
+            await videoEl.play();
+          }
+          lineEl?.classList.add('animate');
+          setStatus('Camera active. Align the sticker inside the frame.', 'info');
+        } catch (error) {
+          console.warn('Camera start failed', error);
+          setStatus('Camera not available. Use manual entry instead.', 'error');
+        }
+      }
+
+      function closeModal() {
+        if (modal.hidden) return;
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden', 'true');
+        modal.removeAttribute('data-context');
+        document.body.classList.remove('scan-modal-open');
+        currentContext = null;
+        if (inputEl) {
+          inputEl.value = '';
+          inputEl.placeholder = defaultPlaceholder;
+        }
+        setStatus('');
+        stopCamera();
+      }
+
+      function openModal(target) {
+        const context = contexts[target];
+        if (!context) {
+          console.warn('Unknown scan context', target);
+          return;
+        }
+        currentContext = context;
+        if (titleEl) titleEl.textContent = context.title;
+        if (descriptionEl) descriptionEl.textContent = context.description;
+        if (inputEl) {
+          inputEl.value = '';
+          inputEl.placeholder = context.placeholder || defaultPlaceholder;
+        }
+        setStatus('Focus the field below and scan a sticker.', 'info');
+        modal.hidden = false;
+        modal.setAttribute('aria-hidden', 'false');
+        modal.dataset.context = target;
+        document.body.classList.add('scan-modal-open');
+        stopCamera();
+        setTimeout(() => {
+          inputEl?.focus();
+          inputEl?.select?.();
+        }, 50);
+      }
+
+      function handleScan(raw, { simulated = false } = {}) {
+        if (!currentContext) {
+          setStatus('Choose a list to scan into first.', 'error');
+          return;
+        }
+        const code = String(raw || '').trim();
+        if (!code) {
+          setStatus('Scan a barcode to continue.', 'error');
+          return;
+        }
+        try {
+          const result = currentContext.handler(code);
+          const message = typeof result === 'string' ? result : result?.message || `Captured ${code}`;
+          const variant = result?.variant || 'success';
+          const displayMessage = simulated ? `${message} (simulated)` : message;
+          setStatus(displayMessage, variant);
+          if (result?.toast && typeof showToast === 'function') {
+            showToast(message);
+          }
+          if (inputEl) {
+            inputEl.value = '';
+            inputEl.focus();
+          }
+        } catch (error) {
+          console.error('Scan handler failed', error);
+          setStatus(error.message || 'Unable to process scan.', 'error');
+        }
+      }
+
+      triggers.forEach(btn => {
+        const target = btn.dataset.scanTarget;
+        if (!target) return;
+        btn.addEventListener('click', () => openModal(target));
+      });
+
+      closeButtons.forEach(btn => btn.addEventListener('click', closeModal));
+
+      modal.addEventListener('click', evt => {
+        const action = evt.target?.dataset?.action;
+        if (action === 'close') {
+          closeModal();
+        }
+      });
+
+      document.addEventListener('keydown', evt => {
+        if (evt.key === 'Escape' && !modal.hidden) {
+          closeModal();
+        }
+      });
+
+      window.addEventListener('beforeunload', stopCamera);
+      document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+          stopCamera();
+        }
+      });
+
+      submitBtn?.addEventListener('click', () => handleScan(inputEl?.value));
+      inputEl?.addEventListener('keydown', evt => {
+        if (evt.key === 'Enter') {
+          evt.preventDefault();
+          handleScan(inputEl.value);
+        }
+      });
+
+      startCameraBtn?.addEventListener('click', startCamera);
+      fakeBtn?.addEventListener('click', () => {
+        const fakeCode = `SCAN-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+        handleScan(fakeCode, { simulated: true });
       });
     })();
 


### PR DESCRIPTION
## Summary
- add Quick Scan triggers to inventory, order, inbound, shipment, and return tables
- implement a reusable section scanner modal with camera, fake scan, and keyboard entry support
- wire scans into existing state handlers so each section updates its lists and dashboard metrics automatically

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d7a90f193c832d8550e382f4254a1a