### PR TITLE
Fix Leaflet CDN URLs to satisfy warehouse HQ CSP

### DIFF
--- a/public/warehouse-hq.html
+++ b/public/warehouse-hq.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css" crossorigin="">
   <style>
     :root {
       color-scheme: light dark;
@@ -1877,7 +1877,7 @@
       }
     }
   </style>
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- switch the Leaflet CSS and JS assets in `public/warehouse-hq.html` to load from cdn.jsdelivr so they comply with the page's CSP

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7baeace54832d92036afc9566d425