### PR TITLE
Add self-service scheduling narrative to Warehouse HQ

### DIFF
--- a/public/warehouse-hq.html
+++ b/public/warehouse-hq.html
@@ -3322,6 +3322,18 @@
           <div class="team-identity-meta" id="team-identity-meta"></div>
           <div class="team-roster" id="team-roster"></div>
         </div>
+        <div class="panel light">
+          <h3>Self-Service Scheduling &amp; Time Tracking</h3>
+          <p>Shift orchestration lives inside Warehouse HQ so managers and associates stay aligned without endless spreadsheets.</p>
+          <ul class="list">
+            <li><strong>Employee-driven scheduling:</strong> Drag-and-drop rosters with mobile shift swaps, call-outs and auto-fill instantly ping available substitutes while logging every change for compliance.</li>
+            <li><strong>Time &amp; attendance, anywhere:</strong> Replace punch cards with GPS-enabled clock-in/out, mobile time clocks or geofenced check-ins that sync directly to payroll exports.</li>
+            <li><strong>Unified labor telemetry:</strong> When workers clock in through the scheduling app, they appear in Warehouse HQ in the right zone, and their picks, packs and counts are logged automatically via WMS/ERP syncs and mobile scanners.</li>
+            <li><strong>Communication that sticks:</strong> Built-in team chat, alerts and push notifications broadcast updates, overtime warnings and break reminders without leaving the floor.</li>
+            <li><strong>Free and flexible tooling:</strong> Spin up small teams with zero-cost tiers like Sling (forever-free scheduling + time clock), Connecteam (free geofenced tracking for up to 10 staff), Homebase (free up to 20 employees) or Clockify (free mobile time tracker). Layer in WP-HR Manager for basic recruiting, applicant tracking and payroll notes.</li>
+            <li><strong>Metrics that matter:</strong> Digital records roll up to leadership dashboards so supervisors can spot who is on shift, compare throughput vs. targets and adjust staffing on the fly.</li>
+          </ul>
+        </div>
         <div class="grid grid-2">
           <form id="task-form" class="panel light">
             <h3>Assign Task</h3>


### PR DESCRIPTION
## Summary
- add a self-service scheduling and time tracking panel to the Warehouse HQ labor section
- highlight GPS-enabled attendance, communication tools, compliance logging, and free scheduling app options
- describe how staffing data syncs with WMS/ERP telemetry for real-time visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d84741423c832daa481685bb93e0d9