### PR TITLE
Add Warehouse HQ workspace API and live data toggle

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const createShopifyRouter = require('./routes/shopify');
 const createAuditRouter = require('./routes/audit');
 const createDesignRouter = require('./routes/design');
 const createTeamRouter = require('./routes/teams');
+const createWarehouseRouter = require('./routes/warehouse');
 const { bootstrapDemoData, shouldBootstrapDemo, DEMO_DEFAULTS } = require('./lib/bootstrapDemo');
 
 const jwt = require('jsonwebtoken');
@@ -86,6 +87,7 @@ app.use('/api/shopify', createShopifyRouter());
 app.use('/api/audit', createAuditRouter());
 app.use('/api/design', createDesignRouter());
 app.use('/api/teams', createTeamRouter());
+app.use('/api/warehouse', createWarehouseRouter());
 
 // 👉 Serve the landing page & assets from /public
 app.use(express.static(path.join(__dirname, 'public')));

--- a/public/warehouse-hq.html
+++ b/public/warehouse-hq.html
@@ -59,6 +59,46 @@
       padding: 1.5rem 1.25rem;
     }
 
+    .header-actions {
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .mode-toggle {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 0.25rem;
+      padding: 0.35rem 0.45rem;
+      border-radius: 0.75rem;
+      background: rgba(15, 23, 42, 0.6);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .mode-toggle span {
+      font-size: 0.72rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .mode-toggle button {
+      border: none;
+      border-radius: 0.6rem;
+      padding: 0.35rem 0.75rem;
+      background: var(--accent-strong);
+      color: var(--text);
+      font-weight: 600;
+      font-size: 0.82rem;
+      cursor: pointer;
+      transition: background 0.2s ease, transform 0.2s ease;
+    }
+
+    .mode-toggle button:hover {
+      background: var(--accent);
+      transform: translateY(-1px);
+    }
+
     h1 {
       font-size: clamp(1.75rem, 2.2vw, 2.5rem);
       margin: 0;
@@ -2567,6 +2607,10 @@
         </div>
         <div class="flex header-actions">
           <div class="badge">Multi-tenant • Cloud-Ready • Free Forever Core</div>
+          <div class="mode-toggle" id="mode-toggle" role="status" aria-live="polite">
+            <span id="mode-status">Live workspace</span>
+            <button type="button" id="mode-toggle-btn" aria-pressed="false">View demo data</button>
+          </div>
           <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="hq-navigation">
             <span class="sr-only">Toggle navigation</span>
             <span class="line" aria-hidden="true"></span>
@@ -4146,6 +4190,11 @@
 
   <script>
     const STORAGE_KEY = 'warehouse-hq-state-v1';
+    const MODE_STORAGE_KEY = 'warehouse-hq-mode';
+    const MODE_LIVE = 'live';
+    const MODE_DEMO = 'demo';
+    let currentMode = loadWorkspaceMode();
+    let allowDemoRosterFallback = currentMode === MODE_DEMO;
     const SHIFT_STATUS_LEVELS = ['alert', 'swap-requested', 'acknowledged', 'published'];
     const state = loadState();
     const warehouseSelects = ['item-warehouse', 'order-warehouse', 'receipt-warehouse', 'cycle-warehouse'];
@@ -4217,6 +4266,180 @@
       }
     ];
     const LABOR_DEFAULT_CHANNEL = 'All Hands';
+
+    function saveWorkspaceMode(mode) {
+      try {
+        localStorage.setItem(MODE_STORAGE_KEY, mode);
+      } catch (err) {
+        console.warn('Failed to persist workspace mode', err);
+      }
+    }
+
+    function updateModeUi() {
+      const status = document.getElementById('mode-status');
+      const btn = document.getElementById('mode-toggle-btn');
+      if (!status || !btn) return;
+      if (currentMode === MODE_LIVE) {
+        status.textContent = 'Live workspace';
+        btn.textContent = 'View demo data';
+        btn.setAttribute('aria-pressed', 'false');
+      } else {
+        status.textContent = 'Demo walkthrough';
+        btn.textContent = 'Return to live data';
+        btn.setAttribute('aria-pressed', 'true');
+      }
+    }
+
+    async function fetchJson(url, options = {}) {
+      const response = await fetch(url, options);
+      let payload = null;
+      try {
+        payload = await response.json();
+      } catch (err) {
+        payload = null;
+      }
+      if (!response.ok) {
+        const error = new Error(payload?.error || response.statusText || 'Request failed');
+        error.status = response.status;
+        error.payload = payload;
+        throw error;
+      }
+      return payload;
+    }
+
+    function postJson(url, body, options = {}) {
+      const headers = Object.assign({ 'Content-Type': 'application/json' }, options.headers || {});
+      return fetchJson(url, {
+        method: options.method || 'POST',
+        headers,
+        body: JSON.stringify(body || {}),
+      });
+    }
+
+    function applyWorkspaceSnapshot(snapshot) {
+      if (!snapshot || typeof snapshot !== 'object') return;
+      const rosterSource = Array.isArray(snapshot.roster)
+        ? snapshot.roster
+        : Array.isArray(snapshot.teamMembers)
+          ? snapshot.teamMembers
+          : [];
+      const previousFallback = allowDemoRosterFallback;
+      allowDemoRosterFallback = false;
+      state.teamMembers = normalizeTeamMembers(rosterSource);
+      state.tasks = Array.isArray(snapshot.tasks)
+        ? snapshot.tasks.map(task => ensureTaskShape(task, state.teamMembers)).filter(Boolean)
+        : [];
+      state.shifts = Array.isArray(snapshot.shifts)
+        ? snapshot.shifts.map(shift => ensureShift(shift, state.teamMembers)).filter(Boolean)
+        : [];
+      state.timePunches = Array.isArray(snapshot.timePunches)
+        ? snapshot.timePunches.map(entry => ensureTimePunch(entry, state.teamMembers, state.shifts)).filter(Boolean)
+        : [];
+      state.laborBroadcasts = Array.isArray(snapshot.broadcasts)
+        ? snapshot.broadcasts.map(entry => ensureLaborBroadcast(entry, state.teamMembers)).filter(Boolean)
+        : [];
+      if (Array.isArray(snapshot.gamification)) {
+        state.gamification = snapshot.gamification
+          .map(entry => ({ id: entry.id || crypto.randomUUID(), message: (entry.message || '').trim() }))
+          .filter(entry => entry.message);
+      }
+      state.updatedAt = snapshot.updatedAt || new Date().toISOString();
+      allowDemoRosterFallback = previousFallback;
+    }
+
+    function upsertShiftFromServer(shift, roster) {
+      if (!shift) return null;
+      const normalized = ensureShift(shift, roster);
+      const idx = state.shifts.findIndex(entry => entry.id === normalized.id);
+      if (idx >= 0) {
+        state.shifts[idx] = normalized;
+      } else {
+        state.shifts.unshift(normalized);
+        state.shifts = state.shifts.slice(0, 48);
+      }
+      return normalized;
+    }
+
+    function insertBroadcastFromServer(broadcast, roster) {
+      const normalized = broadcast ? ensureLaborBroadcast(broadcast, roster) : null;
+      if (!normalized) return null;
+      state.laborBroadcasts.unshift(normalized);
+      state.laborBroadcasts = state.laborBroadcasts.slice(0, 80);
+      return normalized;
+    }
+
+    function insertTimeEventFromServer(event, roster) {
+      if (!event) return null;
+      const normalized = ensureTimePunch(event, roster, state.shifts);
+      state.timePunches.unshift(normalized);
+      state.timePunches = state.timePunches.slice(0, 120);
+      return normalized;
+    }
+
+    function insertTaskFromServer(task, roster) {
+      if (!task) return null;
+      const normalized = ensureTaskShape(task, roster);
+      state.tasks.push(normalized);
+      return normalized;
+    }
+
+    async function refreshWorkspaceFromServer(options = {}) {
+      if (currentMode !== MODE_LIVE) return null;
+      try {
+        const data = await fetchJson('/api/warehouse/state');
+        if (data?.workspace) {
+          applyWorkspaceSnapshot(data.workspace);
+          persist();
+          if (!options.skipRender) {
+            initializeUI();
+          }
+          if (options.showToast) {
+            showToast('Live workspace refreshed.');
+          }
+          return data.workspace;
+        }
+      } catch (err) {
+        console.error('Failed to refresh workspace', err);
+        if (options.errorToast) {
+          showToast(options.errorToast);
+        }
+      }
+      return null;
+    }
+
+    async function createLiveTask(payload, roster) {
+      const response = await postJson('/api/warehouse/tasks', payload);
+      return insertTaskFromServer(response?.task, roster);
+    }
+
+    async function createLiveShift(payload, roster) {
+      const response = await postJson('/api/warehouse/shifts', payload);
+      const shift = upsertShiftFromServer(response?.shift, roster);
+      insertBroadcastFromServer(response?.broadcast, roster);
+      return shift;
+    }
+
+    async function postLiveShiftEvent(shiftId, payload, roster) {
+      const response = await postJson(`/api/warehouse/shifts/${shiftId}/events`, payload);
+      const shift = upsertShiftFromServer(response?.shift, roster);
+      insertBroadcastFromServer(response?.broadcast, roster);
+      return shift;
+    }
+
+    async function createLiveTimeEvent(payload, roster) {
+      const response = await postJson('/api/warehouse/time-events', payload);
+      const punch = insertTimeEventFromServer(response?.timeEvent, roster);
+      if (response?.shift) {
+        upsertShiftFromServer(response.shift, roster);
+      }
+      insertBroadcastFromServer(response?.broadcast, roster);
+      return punch;
+    }
+
+    async function createLiveBroadcast(payload, roster) {
+      const response = await postJson('/api/warehouse/broadcasts', payload);
+      return insertBroadcastFromServer(response?.broadcast, roster);
+    }
 
     function createDefaultTeamMembers(){
       return [
@@ -4438,7 +4661,10 @@
     }
 
     function normalizeTeamMembers(list){
-      const base = Array.isArray(list) && list.length ? list : createDefaultTeamMembers();
+      const hasMembers = Array.isArray(list) && list.length;
+      const base = hasMembers
+        ? list
+        : (allowDemoRosterFallback ? createDefaultTeamMembers() : []);
       return base.map(ensureTeamMember).filter(Boolean);
     }
 
@@ -4674,54 +4900,90 @@
       integrationFormHint.textContent = MANUAL_FORM_HINT;
     }
 
+    const modeToggleBtn = document.getElementById('mode-toggle-btn');
+    if (modeToggleBtn) {
+      modeToggleBtn.addEventListener('click', async () => {
+        if (currentMode === MODE_LIVE) {
+          currentMode = MODE_DEMO;
+          allowDemoRosterFallback = true;
+          saveWorkspaceMode(MODE_DEMO);
+          syncState(seedState());
+          persist();
+          updateModeUi();
+          initializeUI();
+          showToast('Demo filler data enabled.');
+        } else {
+          currentMode = MODE_LIVE;
+          allowDemoRosterFallback = false;
+          saveWorkspaceMode(MODE_LIVE);
+          syncState(seedLiveState());
+          persist();
+          updateModeUi();
+          initializeUI();
+          await refreshWorkspaceFromServer({ showToast: true, errorToast: 'Unable to load live workspace.' });
+        }
+      });
+    }
+    updateModeUi();
+
+    function loadWorkspaceMode() {
+      try {
+        const raw = localStorage.getItem(MODE_STORAGE_KEY);
+        if (raw === MODE_DEMO) return MODE_DEMO;
+        if (raw === MODE_LIVE) return MODE_LIVE;
+      } catch (err) {
+        console.warn('Failed to load workspace mode', err);
+      }
+      return MODE_LIVE;
+    }
+
     function loadState() {
+      let data = null;
       try {
         const raw = localStorage.getItem(STORAGE_KEY);
         if (raw) {
-          const data = JSON.parse(raw);
-          if (!data.branding) {
-            data.branding = seedState().branding;
-          }
-          if (!Array.isArray(data.items)) data.items = [];
-          data.items.forEach(item => {
-            item.color = sanitizeColor(item.color);
-          });
-          if (!Array.isArray(data.collections)) data.collections = [];
-          if (!Array.isArray(data.giftCards)) data.giftCards = [];
-          if (!Array.isArray(data.purchaseOrders)) data.purchaseOrders = [];
-          if (!Array.isArray(data.transfers)) data.transfers = [];
-          if (!Array.isArray(data.shopifyWarnings)) data.shopifyWarnings = [];
-          data.teamMembers = normalizeTeamMembers(data.teamMembers);
-          if (!Array.isArray(data.tasks)) data.tasks = [];
-          data.tasks = data.tasks.map(task => ensureTaskShape(task, data.teamMembers)).filter(Boolean);
-          if (!Array.isArray(data.shifts)) data.shifts = createDefaultShifts(data.teamMembers);
-          data.shifts = data.shifts.map(shift => ensureShift(shift, data.teamMembers)).filter(Boolean);
-          if (!Array.isArray(data.timePunches)) data.timePunches = createDefaultTimePunches(data.teamMembers, data.shifts);
-          data.timePunches = data.timePunches.map(entry => ensureTimePunch(entry, data.teamMembers, data.shifts)).filter(Boolean);
-          if (!Array.isArray(data.laborBroadcasts)) data.laborBroadcasts = createDefaultLaborBroadcasts(data.teamMembers);
-          data.laborBroadcasts = data.laborBroadcasts.map(entry => ensureLaborBroadcast(entry, data.teamMembers)).filter(Boolean);
-          if (!('lastShopifySync' in data)) data.lastShopifySync = null;
-          if (!('lastShopifySyncSource' in data)) data.lastShopifySyncSource = null;
-          return data;
+          data = JSON.parse(raw);
         }
       } catch (err) {
         console.warn('Failed to load state', err);
       }
-      const fallback = seedState();
-      fallback.teamMembers = normalizeTeamMembers(fallback.teamMembers);
-      fallback.tasks = Array.isArray(fallback.tasks)
-        ? fallback.tasks.map(task => ensureTaskShape(task, fallback.teamMembers)).filter(Boolean)
-        : [];
-      fallback.shifts = Array.isArray(fallback.shifts)
-        ? fallback.shifts.map(shift => ensureShift(shift, fallback.teamMembers)).filter(Boolean)
-        : createDefaultShifts(fallback.teamMembers);
-      fallback.timePunches = Array.isArray(fallback.timePunches)
-        ? fallback.timePunches.map(entry => ensureTimePunch(entry, fallback.teamMembers, fallback.shifts)).filter(Boolean)
-        : createDefaultTimePunches(fallback.teamMembers, fallback.shifts);
-      fallback.laborBroadcasts = Array.isArray(fallback.laborBroadcasts)
-        ? fallback.laborBroadcasts.map(entry => ensureLaborBroadcast(entry, fallback.teamMembers)).filter(Boolean)
-        : createDefaultLaborBroadcasts(fallback.teamMembers);
-      return fallback;
+      if (!data || typeof data !== 'object') {
+        data = currentMode === MODE_DEMO ? seedState() : seedLiveState();
+      }
+      if (!data.branding) {
+        data.branding = seedState().branding;
+      }
+      if (!Array.isArray(data.items)) data.items = [];
+      data.items.forEach(item => {
+        item.color = sanitizeColor(item.color);
+      });
+      if (!Array.isArray(data.collections)) data.collections = [];
+      if (!Array.isArray(data.giftCards)) data.giftCards = [];
+      if (!Array.isArray(data.purchaseOrders)) data.purchaseOrders = [];
+      if (!Array.isArray(data.transfers)) data.transfers = [];
+      if (!Array.isArray(data.shopifyWarnings)) data.shopifyWarnings = [];
+      data.teamMembers = normalizeTeamMembers(data.teamMembers);
+      if (!Array.isArray(data.tasks)) data.tasks = [];
+      data.tasks = data.tasks.map(task => ensureTaskShape(task, data.teamMembers)).filter(Boolean);
+      if (!Array.isArray(data.shifts)) {
+        data.shifts = allowDemoRosterFallback ? createDefaultShifts(data.teamMembers) : [];
+      }
+      data.shifts = data.shifts.map(shift => ensureShift(shift, data.teamMembers)).filter(Boolean);
+      if (!Array.isArray(data.timePunches)) {
+        data.timePunches = allowDemoRosterFallback ? createDefaultTimePunches(data.teamMembers, data.shifts) : [];
+      }
+      data.timePunches = data.timePunches.map(entry => ensureTimePunch(entry, data.teamMembers, data.shifts)).filter(Boolean);
+      if (!Array.isArray(data.laborBroadcasts)) {
+        data.laborBroadcasts = allowDemoRosterFallback ? createDefaultLaborBroadcasts(data.teamMembers) : [];
+      }
+      data.laborBroadcasts = data.laborBroadcasts.map(entry => ensureLaborBroadcast(entry, data.teamMembers)).filter(Boolean);
+      if (!Array.isArray(data.gamification)) data.gamification = [];
+      data.gamification = data.gamification
+        .map(entry => ({ id: entry.id || crypto.randomUUID(), message: (entry.message || '').trim() }))
+        .filter(entry => entry.message);
+      if (!('lastShopifySync' in data)) data.lastShopifySync = null;
+      if (!('lastShopifySyncSource' in data)) data.lastShopifySyncSource = null;
+      return data;
     }
 
     function loadScanQueue() {
@@ -5274,6 +5536,17 @@
           logoData: '',
         }
       };
+    }
+
+    function seedLiveState() {
+      const base = seedState();
+      base.teamMembers = [];
+      base.tasks = [];
+      base.shifts = [];
+      base.timePunches = [];
+      base.laborBroadcasts = [];
+      base.gamification = [];
+      return base;
     }
 
     function persist() {
@@ -8582,7 +8855,7 @@
 
     const shiftForm = document.getElementById('shift-form');
     if (shiftForm) {
-      shiftForm.addEventListener('submit', evt => {
+      shiftForm.addEventListener('submit', async evt => {
         evt.preventDefault();
         const form = evt.target;
         const data = Object.fromEntries(new FormData(form).entries());
@@ -8601,6 +8874,31 @@
           owner: owner?.name || data.owner || '',
           ownerId: owner?.id || null,
         };
+        if (currentMode === MODE_LIVE) {
+          try {
+            const livePayload = Object.assign({}, payload, {
+              actorSnapshot: buildTaskOwnerSnapshot(null, 'Warehouse HQ'),
+            });
+            const shift = await createLiveShift(livePayload, roster);
+            if (!shift) {
+              showToast('Unable to publish shift. Try again.');
+              return;
+            }
+            persist();
+            renderShiftBoard();
+            renderLaborTelemetry();
+            renderLaborKpis();
+            renderLaborBroadcasts();
+            populateShiftSelect();
+            showToast('Shift published for self-service scheduling.');
+            form.reset();
+          } catch (err) {
+            console.error('Shift publish error', err);
+            const message = err?.message || 'Unable to publish shift right now.';
+            showToast(message);
+          }
+          return;
+        }
         const shift = ensureShift(payload, roster);
         state.shifts.unshift(shift);
         state.shifts = state.shifts.slice(0, 48);
@@ -8647,7 +8945,7 @@
 
     const shiftBoard = document.getElementById('shift-board');
     if (shiftBoard) {
-      shiftBoard.addEventListener('click', evt => {
+      shiftBoard.addEventListener('click', async evt => {
         const button = evt.target.closest('button[data-action]');
         if (!button) return;
         const { action, id } = button.dataset;
@@ -8659,6 +8957,71 @@
         const actorSnapshot = actorMember
           ? buildTaskOwnerSnapshot(actorMember, actorMember.name)
           : buildTaskOwnerSnapshot(null, 'Warehouse HQ');
+
+        const getBroadcastPayload = (message, channel, priority) => ({
+          message,
+          channel,
+          priority,
+          authorSnapshot: actorSnapshot,
+          authorId: actorSnapshot?.id || null,
+        });
+
+        if (currentMode === MODE_LIVE) {
+          let message = '';
+          let level = 'info';
+          let channel = shift.zone || 'Labor Alerts';
+          let priority = 'normal';
+          let status = shift.status;
+          if (action === 'ack-shift') {
+            message = 'Shift acknowledged and visibility updated for leadership.';
+            level = 'success';
+            channel = 'Leadership Standup';
+            status = 'acknowledged';
+          } else if (action === 'swap-shift') {
+            message = 'Swap blast triggered to flex bench to cover open slots.';
+            level = 'alert';
+            priority = 'high';
+            status = 'swap-requested';
+          } else if (action === 'resolve-shift') {
+            message = 'Coverage confirmed and alerts cleared.';
+            level = 'success';
+            status = 'acknowledged';
+          }
+          try {
+            const payload = {
+              message,
+              level,
+              status,
+              actorSnapshot,
+            };
+            if (message) {
+              payload.broadcast = getBroadcastPayload(message, channel, priority);
+            }
+            const updated = await postLiveShiftEvent(id, payload, roster);
+            if (!updated) {
+              showToast('Unable to update shift. Try again.');
+              return;
+            }
+            persist();
+            renderShiftBoard();
+            renderLaborTelemetry();
+            renderLaborKpis();
+            renderLaborBroadcasts();
+            if (action === 'ack-shift') {
+              showToast('Shift acknowledged across mobile and HQ.');
+            } else if (action === 'swap-shift') {
+              showToast('Swap request broadcast to available associates.');
+            } else if (action === 'resolve-shift') {
+              showToast('Shift marked as covered.');
+            }
+          } catch (err) {
+            console.error('Shift event error', err);
+            const messageText = err?.message || 'Unable to update shift right now.';
+            showToast(messageText);
+          }
+          return;
+        }
+
         if (action === 'ack-shift') {
           shift.status = 'acknowledged';
           appendShiftActivity(id, 'Shift acknowledged and visibility updated for leadership.', {
@@ -8730,24 +9093,78 @@
 
     const timeClockForm = document.getElementById('time-clock-form');
     if (timeClockForm) {
-      timeClockForm.addEventListener('submit', evt => {
+      timeClockForm.addEventListener('submit', async evt => {
         evt.preventDefault();
         const form = evt.target;
         const data = Object.fromEntries(new FormData(form).entries());
         const roster = getRosterMembers();
         const member = matchTeamMember(roster, data.member, data.memberId);
+        const timestampIso = data.timestamp ? new Date(data.timestamp).toISOString() : new Date().toISOString();
+        const geoProvided = data.lat || data.lng || data.accuracy;
         const payload = {
           member: member?.name || data.member,
           memberId: member?.id || null,
           shiftId: data.shiftId || null,
           type: data.type,
           method: data.method,
-          timestamp: data.timestamp ? new Date(data.timestamp).toISOString() : new Date().toISOString(),
+          timestamp: timestampIso,
           notes: data.notes,
-          geo: (data.lat || data.lng || data.accuracy)
-            ? { lat: data.lat, lng: data.lng, accuracy: data.accuracy }
-            : undefined,
+          geo: geoProvided ? { lat: data.lat, lng: data.lng, accuracy: data.accuracy } : undefined,
         };
+        if (currentMode === MODE_LIVE) {
+          try {
+            let shift = null;
+            let appendActivity = null;
+            const memberSnapshot = member
+              ? buildTaskOwnerSnapshot(member, member.name)
+              : buildTaskOwnerSnapshot(null, data.member || 'Team member');
+            if (payload.shiftId) {
+              shift = state.shifts.find(entry => entry.id === payload.shiftId) || null;
+              const message = `${memberSnapshot.name || payload.member || 'Team member'} ${describePunchType(payload.type)} (${formatPunchMethod(payload.method)})`;
+              const level = payload.type === 'call-out'
+                ? 'alert'
+                : payload.type === 'clock-in'
+                  ? 'success'
+                  : 'info';
+              appendActivity = {
+                message,
+                level,
+                actorSnapshot: memberSnapshot,
+              };
+              if (payload.type === 'call-out') {
+                payload.status = 'alert';
+                appendActivity.broadcast = {
+                  message,
+                  channel: shift?.zone || 'Labor Alerts',
+                  priority: 'high',
+                  authorSnapshot: memberSnapshot,
+                  authorId: memberSnapshot?.id || null,
+                };
+              }
+            }
+            if (appendActivity) {
+              payload.appendActivity = appendActivity;
+            }
+            const punch = await createLiveTimeEvent(payload, roster);
+            if (!punch) {
+              showToast('Unable to log event. Try again.');
+              return;
+            }
+            persist();
+            renderTimePunches();
+            renderLaborTelemetry();
+            renderLaborKpis();
+            renderShiftBoard();
+            renderLaborBroadcasts();
+            showToast('Labor telemetry updated.');
+            form.reset();
+          } catch (err) {
+            console.error('Time event error', err);
+            const message = err?.message || 'Unable to log event right now.';
+            showToast(message);
+          }
+          return;
+        }
         const punch = ensureTimePunch(payload, roster, state.shifts);
         state.timePunches.unshift(punch);
         state.timePunches = state.timePunches.slice(0, 120);
@@ -8782,7 +9199,7 @@
 
     const laborBroadcastForm = document.getElementById('labor-broadcast-form');
     if (laborBroadcastForm) {
-      laborBroadcastForm.addEventListener('submit', evt => {
+      laborBroadcastForm.addEventListener('submit', async evt => {
         evt.preventDefault();
         const form = evt.target;
         const data = Object.fromEntries(new FormData(form).entries());
@@ -8797,6 +9214,25 @@
           authorId: author?.id || null,
           authorSnapshot: author ? buildTaskOwnerSnapshot(author, author.name) : buildTaskOwnerSnapshot(null, data.author || 'Warehouse HQ'),
         };
+        if (currentMode === MODE_LIVE) {
+          try {
+            const broadcast = await createLiveBroadcast(payload, roster);
+            if (!broadcast) {
+              showToast('Message required to broadcast.');
+              return;
+            }
+            persist();
+            renderLaborBroadcasts();
+            renderLaborTelemetry();
+            showToast('Broadcast queued for delivery across channels.');
+            form.reset();
+          } catch (err) {
+            console.error('Broadcast error', err);
+            const message = err?.message || 'Unable to send broadcast right now.';
+            showToast(message);
+          }
+          return;
+        }
         const broadcast = ensureLaborBroadcast(payload, roster);
         if (!broadcast) {
           showToast('Message required to broadcast.');
@@ -8952,32 +9388,60 @@
       if (action === 'close-task') closeTask(id);
     });
 
-    document.getElementById('task-form').addEventListener('submit', evt => {
-      evt.preventDefault();
-      const form = evt.target;
-      const data = Object.fromEntries(new FormData(form).entries());
-      const roster = getRosterMembers();
-      const ownerMatch = matchTeamMember(roster, data.owner);
-      const task = {
-        id: crypto.randomUUID(),
-        title: data.title,
-        owner: data.owner,
-        ownerId: ownerMatch?.id || null,
-        ownerSnapshot: buildTaskOwnerSnapshot(ownerMatch, data.owner),
-        type: data.type,
-        dueDate: data.dueDate,
-        link: data.link,
-        status: 'open',
-        createdAt: new Date().toISOString(),
-        activity: [],
-      };
-      appendTaskActivity(task, 'Dispatched mission to floor', 'team');
-      state.tasks.push(task);
-      persist();
-      renderTasks();
-      showToast('Task dispatched to floor.');
-      form.reset();
-    });
+    const taskForm = document.getElementById('task-form');
+    if (taskForm) {
+      taskForm.addEventListener('submit', async evt => {
+        evt.preventDefault();
+        const form = evt.target;
+        const data = Object.fromEntries(new FormData(form).entries());
+        const roster = getRosterMembers();
+        const ownerMatch = matchTeamMember(roster, data.owner);
+        if (currentMode === MODE_LIVE) {
+          try {
+            const task = await createLiveTask({
+              title: data.title,
+              owner: ownerMatch?.name || data.owner || '',
+              ownerId: ownerMatch?.id || null,
+              type: data.type,
+              dueDate: data.dueDate,
+              link: data.link,
+            }, roster);
+            if (!task) {
+              showToast('Unable to dispatch task. Try again.');
+              return;
+            }
+            persist();
+            renderTasks();
+            showToast('Task dispatched to floor.');
+            form.reset();
+          } catch (err) {
+            console.error('Task dispatch error', err);
+            const message = err?.message || 'Unable to dispatch task right now.';
+            showToast(message);
+          }
+          return;
+        }
+        const task = {
+          id: crypto.randomUUID(),
+          title: data.title,
+          owner: data.owner,
+          ownerId: ownerMatch?.id || null,
+          ownerSnapshot: buildTaskOwnerSnapshot(ownerMatch, data.owner),
+          type: data.type,
+          dueDate: data.dueDate,
+          link: data.link,
+          status: 'open',
+          createdAt: new Date().toISOString(),
+          activity: [],
+        };
+        appendTaskActivity(task, 'Dispatched mission to floor', 'team');
+        state.tasks.push(task);
+        persist();
+        renderTasks();
+        showToast('Task dispatched to floor.');
+        form.reset();
+      });
+    }
 
     document.getElementById('plan-cycle').addEventListener('click', () => {
       const warehouseId = document.getElementById('cycle-warehouse').value;
@@ -9556,6 +10020,17 @@
       renderLaborKpis();
       renderLaborBroadcasts();
       renderLaborTools();
+    }
+
+    async function bootstrapWorkspace() {
+      if (currentMode === MODE_LIVE) {
+        allowDemoRosterFallback = false;
+        initializeUI();
+        await refreshWorkspaceFromServer({ errorToast: 'Unable to load live workspace.' });
+      } else {
+        allowDemoRosterFallback = true;
+        initializeUI();
+      }
     }
 
     applyBranding();
@@ -10170,7 +10645,7 @@
 
     handleNavigation();
     drainStoredScanQueue();
-    initializeUI();
+    bootstrapWorkspace();
   </script>
 </body>
 </html>

--- a/routes/warehouse.js
+++ b/routes/warehouse.js
@@ -1,0 +1,541 @@
+const express = require('express');
+const crypto = require('crypto');
+const { getCollection } = require('../services/mongo');
+
+const WORKSPACE_ID = 'warehouse-hq';
+const MAX_TASK_HISTORY = 200;
+const MAX_SHIFTS = 120;
+const MAX_SHIFT_ACTIVITY = 40;
+const MAX_TIME_EVENTS = 400;
+const MAX_BROADCASTS = 200;
+const MAX_GAMIFICATION = 80;
+
+function nowIso(){
+  return new Date().toISOString();
+}
+
+function baseWorkspace(){
+  const now = nowIso();
+  return {
+    _id: WORKSPACE_ID,
+    createdAt: now,
+    updatedAt: now,
+    roster: [],
+    tasks: [],
+    shifts: [],
+    timePunches: [],
+    broadcasts: [],
+    gamification: [],
+  };
+}
+
+function sanitizeString(value){
+  if (value === null || value === undefined) return '';
+  return String(value).trim();
+}
+
+function sanitizeNumber(value, fallback = 0){
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function sanitizeBoolean(value){
+  return value === true || value === 'true' || value === '1' || value === 1;
+}
+
+function sanitizeMember(input = {}){
+  const member = { ...input };
+  member.id = sanitizeString(member.id) || crypto.randomUUID();
+  member.name = sanitizeString(member.name) || 'Crew Member';
+  member.role = sanitizeString(member.role) || 'Specialist';
+  member.team = sanitizeString(member.team);
+  member.headline = sanitizeString(member.headline);
+  member.serviceArea = sanitizeString(member.serviceArea);
+  member.status = sanitizeString(member.status);
+  member.availability = sanitizeString(member.availability);
+  member.privateNote = sanitizeString(member.privateNote);
+  member.contact = sanitizeString(member.contact);
+  member.isFreelancer = sanitizeBoolean(member.isFreelancer);
+  member.tags = Array.isArray(member.tags)
+    ? member.tags.map(tag => sanitizeString(tag)).filter(Boolean)
+    : [];
+  member.aliases = Array.isArray(member.aliases)
+    ? member.aliases.map(alias => sanitizeString(alias)).filter(Boolean)
+    : [];
+  member.photo = sanitizeString(member.photo);
+  member.avatarSeed = sanitizeString(member.avatarSeed) || member.name || member.id;
+  return member;
+}
+
+function sanitizeTask(input = {}){
+  const task = { ...input };
+  task.id = sanitizeString(task.id) || crypto.randomUUID();
+  task.title = sanitizeString(task.title) || 'Untitled mission';
+  task.owner = sanitizeString(task.owner);
+  task.ownerId = sanitizeString(task.ownerId) || null;
+  task.type = sanitizeString(task.type) || 'General';
+  task.dueDate = sanitizeString(task.dueDate) || null;
+  task.link = sanitizeString(task.link);
+  task.status = sanitizeString(task.status) || 'open';
+  task.createdAt = sanitizeString(task.createdAt) || nowIso();
+  task.activity = Array.isArray(task.activity)
+    ? task.activity.map(entry => ({
+        id: sanitizeString(entry.id) || crypto.randomUUID(),
+        actor: sanitizeString(entry.actor) || 'Warehouse HQ',
+        channel: sanitizeString(entry.channel) || 'team',
+        message: sanitizeString(entry.message) || 'Update logged.',
+        timestamp: sanitizeString(entry.timestamp) || nowIso(),
+      })).filter(entry => entry.message)
+    : [];
+  return task;
+}
+
+function sanitizeShiftActivity(entry = {}){
+  return {
+    id: sanitizeString(entry.id) || crypto.randomUUID(),
+    message: sanitizeString(entry.message) || 'Update logged.',
+    timestamp: sanitizeString(entry.timestamp) || nowIso(),
+    level: (sanitizeString(entry.level) || 'info').toLowerCase(),
+    actorSnapshot: entry.actorSnapshot && typeof entry.actorSnapshot === 'object'
+      ? {
+          id: sanitizeString(entry.actorSnapshot.id) || null,
+          name: sanitizeString(entry.actorSnapshot.name) || 'Warehouse HQ',
+          role: sanitizeString(entry.actorSnapshot.role) || 'Member',
+          team: sanitizeString(entry.actorSnapshot.team),
+          headline: sanitizeString(entry.actorSnapshot.headline),
+          serviceArea: sanitizeString(entry.actorSnapshot.serviceArea),
+          status: sanitizeString(entry.actorSnapshot.status),
+          availability: sanitizeString(entry.actorSnapshot.availability),
+          tags: Array.isArray(entry.actorSnapshot.tags)
+            ? entry.actorSnapshot.tags.map(tag => sanitizeString(tag)).filter(Boolean)
+            : [],
+          privateNote: sanitizeString(entry.actorSnapshot.privateNote),
+          contact: sanitizeString(entry.actorSnapshot.contact),
+          isFreelancer: sanitizeBoolean(entry.actorSnapshot.isFreelancer),
+          photo: sanitizeString(entry.actorSnapshot.photo),
+          avatarSeed: sanitizeString(entry.actorSnapshot.avatarSeed),
+        }
+      : null,
+  };
+}
+
+function sanitizeShift(input = {}){
+  const shift = { ...input };
+  shift.id = sanitizeString(shift.id) || crypto.randomUUID();
+  shift.title = sanitizeString(shift.title) || 'Shift';
+  shift.zone = sanitizeString(shift.zone);
+  shift.date = sanitizeString(shift.date) || null;
+  shift.start = sanitizeString(shift.start) || null;
+  shift.end = sanitizeString(shift.end) || null;
+  shift.coverage = sanitizeNumber(shift.coverage, 1);
+  shift.allowMobileSwaps = sanitizeBoolean(shift.allowMobileSwaps);
+  shift.gpsMode = sanitizeString(shift.gpsMode) || 'recommended';
+  shift.notes = sanitizeString(shift.notes);
+  shift.owner = sanitizeString(shift.owner);
+  shift.ownerId = sanitizeString(shift.ownerId) || null;
+  shift.status = sanitizeString(shift.status) || 'published';
+  shift.createdAt = sanitizeString(shift.createdAt) || nowIso();
+  shift.mobileActions = Array.isArray(shift.mobileActions)
+    ? shift.mobileActions.map(entry => sanitizeShiftActivity(entry))
+    : [];
+  return shift;
+}
+
+function sanitizeGeo(geo){
+  if (!geo || typeof geo !== 'object') return null;
+  const lat = Number(geo.lat);
+  const lng = Number(geo.lng);
+  const accuracy = Number(geo.accuracy);
+  const hasLat = Number.isFinite(lat);
+  const hasLng = Number.isFinite(lng);
+  const hasAccuracy = Number.isFinite(accuracy);
+  if (!hasLat && !hasLng && !hasAccuracy) return null;
+  return {
+    lat: hasLat ? lat : null,
+    lng: hasLng ? lng : null,
+    accuracy: hasAccuracy ? accuracy : null,
+  };
+}
+
+function sanitizeTimeEvent(input = {}){
+  const event = { ...input };
+  event.id = sanitizeString(event.id) || crypto.randomUUID();
+  event.member = sanitizeString(event.member);
+  event.memberId = sanitizeString(event.memberId) || null;
+  event.shiftId = sanitizeString(event.shiftId) || null;
+  event.type = sanitizeString(event.type) || 'clock-in';
+  event.method = sanitizeString(event.method) || 'gps';
+  event.timestamp = sanitizeString(event.timestamp) || nowIso();
+  event.notes = sanitizeString(event.notes);
+  event.geo = sanitizeGeo(event.geo);
+  return event;
+}
+
+function sanitizeBroadcast(input = {}){
+  const broadcast = { ...input };
+  broadcast.id = sanitizeString(broadcast.id) || crypto.randomUUID();
+  broadcast.message = sanitizeString(broadcast.message) || 'Update';
+  broadcast.channel = sanitizeString(broadcast.channel) || 'All Hands';
+  broadcast.priority = (sanitizeString(broadcast.priority) || 'normal').toLowerCase();
+  broadcast.createdAt = sanitizeString(broadcast.createdAt) || nowIso();
+  broadcast.author = sanitizeString(broadcast.author) || 'Warehouse HQ';
+  broadcast.authorId = sanitizeString(broadcast.authorId) || null;
+  broadcast.authorSnapshot = broadcast.authorSnapshot && typeof broadcast.authorSnapshot === 'object'
+    ? {
+        id: sanitizeString(broadcast.authorSnapshot.id) || null,
+        name: sanitizeString(broadcast.authorSnapshot.name) || broadcast.author,
+        role: sanitizeString(broadcast.authorSnapshot.role),
+        team: sanitizeString(broadcast.authorSnapshot.team),
+        headline: sanitizeString(broadcast.authorSnapshot.headline),
+        serviceArea: sanitizeString(broadcast.authorSnapshot.serviceArea),
+        status: sanitizeString(broadcast.authorSnapshot.status),
+        availability: sanitizeString(broadcast.authorSnapshot.availability),
+        tags: Array.isArray(broadcast.authorSnapshot.tags)
+          ? broadcast.authorSnapshot.tags.map(tag => sanitizeString(tag)).filter(Boolean)
+          : [],
+        privateNote: sanitizeString(broadcast.authorSnapshot.privateNote),
+        contact: sanitizeString(broadcast.authorSnapshot.contact),
+        isFreelancer: sanitizeBoolean(broadcast.authorSnapshot.isFreelancer),
+        photo: sanitizeString(broadcast.authorSnapshot.photo),
+        avatarSeed: sanitizeString(broadcast.authorSnapshot.avatarSeed),
+      }
+    : null;
+  return broadcast;
+}
+
+function sanitizeGamification(input = {}){
+  const entry = { ...input };
+  entry.id = sanitizeString(entry.id) || crypto.randomUUID();
+  entry.message = sanitizeString(entry.message);
+  entry.createdAt = sanitizeString(entry.createdAt) || nowIso();
+  return entry;
+}
+
+async function loadWorkspace(){
+  const collection = await getCollection('warehouse_workspace');
+  let workspace = await collection.findOne({ _id: WORKSPACE_ID });
+  if (!workspace){
+    workspace = baseWorkspace();
+    await collection.insertOne(workspace);
+  }
+  workspace.roster = Array.isArray(workspace.roster)
+    ? workspace.roster.map(sanitizeMember)
+    : [];
+  workspace.tasks = Array.isArray(workspace.tasks)
+    ? workspace.tasks.map(sanitizeTask)
+    : [];
+  workspace.shifts = Array.isArray(workspace.shifts)
+    ? workspace.shifts.map(sanitizeShift)
+    : [];
+  workspace.timePunches = Array.isArray(workspace.timePunches)
+    ? workspace.timePunches.map(sanitizeTimeEvent)
+    : [];
+  workspace.broadcasts = Array.isArray(workspace.broadcasts)
+    ? workspace.broadcasts.map(sanitizeBroadcast)
+    : [];
+  workspace.gamification = Array.isArray(workspace.gamification)
+    ? workspace.gamification.map(sanitizeGamification)
+    : [];
+  return workspace;
+}
+
+async function persistWorkspace(workspace){
+  const collection = await getCollection('warehouse_workspace');
+  const now = nowIso();
+  const payload = {
+    roster: workspace.roster.slice(0, MAX_TASK_HISTORY),
+    tasks: workspace.tasks.slice(-MAX_TASK_HISTORY),
+    shifts: workspace.shifts.slice(0, MAX_SHIFTS),
+    timePunches: workspace.timePunches.slice(0, MAX_TIME_EVENTS),
+    broadcasts: workspace.broadcasts.slice(0, MAX_BROADCASTS),
+    gamification: workspace.gamification.slice(0, MAX_GAMIFICATION),
+    updatedAt: now,
+  };
+  const createdAt = workspace.createdAt || now;
+  await collection.updateOne(
+    { _id: WORKSPACE_ID },
+    {
+      $set: payload,
+      $setOnInsert: { createdAt },
+    },
+    { upsert: true }
+  );
+  workspace.updatedAt = now;
+  workspace.createdAt = createdAt;
+  return workspace;
+}
+
+function sanitizeWorkspaceResponse(workspace){
+  return {
+    id: workspace._id,
+    createdAt: workspace.createdAt,
+    updatedAt: workspace.updatedAt,
+    roster: workspace.roster.map(sanitizeMember),
+    tasks: workspace.tasks.map(sanitizeTask),
+    shifts: workspace.shifts.map(sanitizeShift),
+    timePunches: workspace.timePunches.map(sanitizeTimeEvent),
+    broadcasts: workspace.broadcasts.map(sanitizeBroadcast),
+    gamification: workspace.gamification.map(sanitizeGamification),
+  };
+}
+
+module.exports = function createWarehouseRouter(){
+  const router = express.Router();
+
+  router.get('/state', async (_req, res) => {
+    try {
+      const workspace = await loadWorkspace();
+      res.json({ ok: true, workspace: sanitizeWorkspaceResponse(workspace) });
+    } catch (err){
+      console.error('warehouse state error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  router.post('/roster', async (req, res) => {
+    try {
+      const workspace = await loadWorkspace();
+      const member = sanitizeMember(req.body || {});
+      if (!member.name){
+        return res.status(400).json({ error: 'name_required' });
+      }
+      const existingIndex = workspace.roster.findIndex(entry => entry.id === member.id);
+      if (existingIndex >= 0){
+        workspace.roster[existingIndex] = member;
+      } else {
+        workspace.roster.push(member);
+      }
+      await persistWorkspace(workspace);
+      res.json({ ok: true, member: sanitizeMember(member) });
+    } catch (err){
+      console.error('warehouse roster error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  router.delete('/roster/:id', async (req, res) => {
+    try {
+      const { id } = req.params;
+      const workspace = await loadWorkspace();
+      const before = workspace.roster.length;
+      workspace.roster = workspace.roster.filter(member => member.id !== id);
+      if (workspace.roster.length === before){
+        return res.status(404).json({ error: 'member_not_found' });
+      }
+      await persistWorkspace(workspace);
+      res.json({ ok: true });
+    } catch (err){
+      console.error('warehouse roster delete error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  router.post('/tasks', async (req, res) => {
+    try {
+      const workspace = await loadWorkspace();
+      const payload = req.body || {};
+      const task = sanitizeTask({
+        title: payload.title,
+        owner: payload.owner,
+        ownerId: payload.ownerId,
+        type: payload.type,
+        dueDate: payload.dueDate,
+        link: payload.link,
+        status: 'open',
+        activity: [
+          {
+            message: 'Dispatched mission to floor.',
+            channel: 'team',
+            actor: 'Warehouse HQ',
+            timestamp: nowIso(),
+          },
+        ],
+      });
+      workspace.tasks.push(task);
+      await persistWorkspace(workspace);
+      res.json({ ok: true, task: sanitizeTask(task) });
+    } catch (err){
+      console.error('warehouse task error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  router.post('/shifts', async (req, res) => {
+    try {
+      const workspace = await loadWorkspace();
+      const payload = req.body || {};
+      const shift = sanitizeShift({
+        title: payload.title,
+        zone: payload.zone,
+        date: payload.date,
+        start: payload.start,
+        end: payload.end,
+        coverage: payload.coverage,
+        allowMobileSwaps: payload.allowMobileSwaps,
+        gpsMode: payload.gpsMode,
+        notes: payload.notes,
+        owner: payload.owner,
+        ownerId: payload.ownerId,
+        status: 'published',
+        mobileActions: [
+          sanitizeShiftActivity({
+            message: 'Shift published to mobile board.',
+            level: 'info',
+            actorSnapshot: payload.actorSnapshot,
+          }),
+        ],
+      });
+      workspace.shifts.unshift(shift);
+      const broadcast = sanitizeBroadcast({
+        message: `${shift.title} published to mobile board.`,
+        channel: shift.zone || 'Labor Alerts',
+        priority: 'normal',
+        author: payload.actorSnapshot?.name || 'Warehouse HQ',
+        authorId: payload.actorSnapshot?.id || null,
+        authorSnapshot: payload.actorSnapshot || null,
+      });
+      workspace.broadcasts.unshift(broadcast);
+      await persistWorkspace(workspace);
+      res.json({ ok: true, shift: sanitizeShift(shift), broadcast: sanitizeBroadcast(broadcast) });
+    } catch (err){
+      console.error('warehouse shift error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  router.post('/shifts/:id/events', async (req, res) => {
+    try {
+      const { id } = req.params;
+      const workspace = await loadWorkspace();
+      const shift = workspace.shifts.find(entry => entry.id === id);
+      if (!shift){
+        return res.status(404).json({ error: 'shift_not_found' });
+      }
+      const payload = req.body || {};
+      const event = sanitizeShiftActivity({
+        message: payload.message,
+        level: payload.level,
+        timestamp: payload.timestamp,
+        actorSnapshot: payload.actorSnapshot,
+      });
+      shift.mobileActions.unshift(event);
+      shift.mobileActions = shift.mobileActions.slice(0, MAX_SHIFT_ACTIVITY);
+      if (payload.status){
+        shift.status = sanitizeString(payload.status) || shift.status;
+      }
+      if (payload.coverage != null){
+        shift.coverage = sanitizeNumber(payload.coverage, shift.coverage);
+      }
+      let broadcast = null;
+      if (payload.broadcast && payload.broadcast.message){
+        broadcast = sanitizeBroadcast({
+          ...payload.broadcast,
+          authorSnapshot: payload.broadcast.authorSnapshot || payload.actorSnapshot || null,
+        });
+        workspace.broadcasts.unshift(broadcast);
+      }
+      await persistWorkspace(workspace);
+      res.json({
+        ok: true,
+        shift: sanitizeShift(shift),
+        broadcast: broadcast ? sanitizeBroadcast(broadcast) : null,
+      });
+    } catch (err){
+      console.error('warehouse shift event error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  router.post('/time-events', async (req, res) => {
+    try {
+      const workspace = await loadWorkspace();
+      const payload = req.body || {};
+      const event = sanitizeTimeEvent({
+        member: payload.member,
+        memberId: payload.memberId,
+        shiftId: payload.shiftId,
+        type: payload.type,
+        method: payload.method,
+        timestamp: payload.timestamp,
+        notes: payload.notes,
+        geo: payload.geo,
+      });
+      workspace.timePunches.unshift(event);
+      workspace.timePunches = workspace.timePunches.slice(0, MAX_TIME_EVENTS);
+      let shift = null;
+      let broadcast = null;
+      if (event.shiftId){
+        shift = workspace.shifts.find(entry => entry.id === event.shiftId) || null;
+        if (shift){
+          if (payload.status){
+            shift.status = sanitizeString(payload.status) || shift.status;
+          }
+          if (payload.appendActivity && payload.appendActivity.message){
+            const activity = sanitizeShiftActivity({
+              message: payload.appendActivity.message,
+              level: payload.appendActivity.level,
+              actorSnapshot: payload.appendActivity.actorSnapshot,
+            });
+            shift.mobileActions.unshift(activity);
+            shift.mobileActions = shift.mobileActions.slice(0, MAX_SHIFT_ACTIVITY);
+            if (payload.appendActivity.broadcast && payload.appendActivity.broadcast.message){
+              broadcast = sanitizeBroadcast({
+                ...payload.appendActivity.broadcast,
+                authorSnapshot: payload.appendActivity.broadcast.authorSnapshot
+                  || payload.appendActivity.actorSnapshot
+                  || null,
+              });
+              workspace.broadcasts.unshift(broadcast);
+            }
+          }
+        }
+      }
+      await persistWorkspace(workspace);
+      res.json({
+        ok: true,
+        timeEvent: sanitizeTimeEvent(event),
+        shift: shift ? sanitizeShift(shift) : null,
+        broadcast: broadcast ? sanitizeBroadcast(broadcast) : null,
+      });
+    } catch (err){
+      console.error('warehouse time event error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  router.post('/broadcasts', async (req, res) => {
+    try {
+      const workspace = await loadWorkspace();
+      const payload = req.body || {};
+      const broadcast = sanitizeBroadcast(payload);
+      if (!broadcast.message){
+        return res.status(400).json({ error: 'message_required' });
+      }
+      workspace.broadcasts.unshift(broadcast);
+      await persistWorkspace(workspace);
+      res.json({ ok: true, broadcast: sanitizeBroadcast(broadcast) });
+    } catch (err){
+      console.error('warehouse broadcast error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  router.post('/gamification', async (req, res) => {
+    try {
+      const workspace = await loadWorkspace();
+      const payload = req.body || {};
+      const entry = sanitizeGamification(payload);
+      if (!entry.message){
+        return res.status(400).json({ error: 'message_required' });
+      }
+      workspace.gamification.unshift(entry);
+      await persistWorkspace(workspace);
+      res.json({ ok: true, entry: sanitizeGamification(entry) });
+    } catch (err){
+      console.error('warehouse gamification error', err);
+      res.status(500).json({ error: 'server_error' });
+    }
+  });
+
+  return router;
+};


### PR DESCRIPTION
## Summary
- add a dedicated `/api/warehouse` router backed by Mongo or file storage to persist roster, tasks, shifts, time events, and broadcasts
- wire the Warehouse HQ page to fetch and sync live workspace data while offering a live/demo toggle
- update labor/task forms to post to the API so real entries stay in sync across users

## Testing
- npm run start *(fails: Stripe credentials missing in local env)*

------
https://chatgpt.com/codex/tasks/task_e_68d8532576f4832d8d05da29c7d7467f