### PR TITLE
Allow Warehouse HQ video autoplay with sound

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,12 +58,13 @@ const demoBootstrapPromise = bootstrapDemoData();
 
 const contentSecurityPolicy = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://cdn.jsdelivr.net https://assets.calendly.com",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://cdn.jsdelivr.net https://assets.calendly.com https://player.vimeo.com",
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://assets.calendly.com",
   "font-src 'self' data: https://fonts.gstatic.com",
   "img-src 'self' data: blob: https://*",
+  "media-src 'self' data: blob: https://cdn.coverr.co https://player.vimeo.com",
   "connect-src 'self' https: wss: data:",
-  "frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://assets.calendly.com https://www.youtube.com",
+  "frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://assets.calendly.com https://www.youtube.com https://player.vimeo.com",
   "form-action 'self' https://hooks.stripe.com",
   "base-uri 'self'",
   "object-src 'none'",

--- a/public/warehouse-hq.html
+++ b/public/warehouse-hq.html
@@ -3662,7 +3662,7 @@
 
         <div class="caseflow-showcase" aria-label="CaseFlow automation highlights">
           <div class="caseflow-hero">
-            <video autoplay muted loop playsinline poster="/image/CaseFlow_WorkerandCPJ-1.png">
+            <video id="caseflow-hero-video" autoplay playsinline preload="auto" controls poster="/image/CaseFlow_WorkerandCPJ-1.png">
               <source src="https://cdn.coverr.co/videos/coverr-a-forklift-in-a-warehouse-7718/1080p.mp4" type="video/mp4" />
             </video>
             <div class="caseflow-hero-content">
@@ -11027,6 +11027,38 @@
 
     document.addEventListener('global-network-refresh', evt => refreshNetworkSnapshots(evt?.detail || {}));
   })();
+
+    (function ensureCaseflowVideoPlayback() {
+      const video = document.getElementById('caseflow-hero-video');
+      if (!video) return;
+
+      video.loop = false;
+      video.muted = false;
+      video.defaultMuted = false;
+      video.volume = 1;
+
+      const attemptPlay = () => {
+        const playPromise = video.play();
+        if (playPromise && typeof playPromise.then === 'function') {
+          playPromise.catch(() => {
+            const resumePlayback = () => {
+              video.play().catch(() => {});
+            };
+            document.addEventListener('pointerdown', resumePlayback, { once: true });
+          });
+        }
+      };
+
+      if (video.readyState >= 3) {
+        attemptPlay();
+      } else {
+        video.addEventListener('canplaythrough', attemptPlay, { once: true });
+      }
+
+      video.addEventListener('ended', () => {
+        video.currentTime = video.duration;
+      });
+    })();
 
     (function registerScannerSync() {
       if (typeof BroadcastChannel === 'function') {


### PR DESCRIPTION
## Summary
- update the content security policy so Vimeo scripts/frames and Coverr media can load
- change the CaseFlow hero video to preload with controls and no looping, then script its playback with sound

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d87854c4c0832d931f19e32d05f194