### PR TITLE
Remove deprecated workspace mode toggle from Warehouse HQ page

### DIFF
--- a/public/warehouse-hq.html
+++ b/public/warehouse-hq.html
@@ -64,41 +64,6 @@
       gap: 0.75rem;
     }
 
-    .mode-toggle {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-end;
-      gap: 0.25rem;
-      padding: 0.35rem 0.45rem;
-      border-radius: 0.75rem;
-      background: rgba(15, 23, 42, 0.6);
-      border: 1px solid rgba(148, 163, 184, 0.25);
-    }
-
-    .mode-toggle span {
-      font-size: 0.72rem;
-      color: var(--text-muted);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-    }
-
-    .mode-toggle button {
-      border: none;
-      border-radius: 0.6rem;
-      padding: 0.35rem 0.75rem;
-      background: var(--accent-strong);
-      color: var(--text);
-      font-weight: 600;
-      font-size: 0.82rem;
-      cursor: pointer;
-      transition: background 0.2s ease, transform 0.2s ease;
-    }
-
-    .mode-toggle button:hover {
-      background: var(--accent);
-      transform: translateY(-1px);
-    }
-
     h1 {
       font-size: clamp(1.75rem, 2.2vw, 2.5rem);
       margin: 0;
@@ -2898,10 +2863,6 @@
         </div>
         <div class="flex header-actions">
           <div class="badge">Multi-tenant • Cloud-Ready • Free Forever Core</div>
-          <div class="mode-toggle" id="mode-toggle" role="status" aria-live="polite">
-            <span id="mode-status">Live workspace</span>
-            <button type="button" id="mode-toggle-btn" aria-pressed="false">View demo data</button>
-          </div>
           <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="hq-navigation">
             <span class="sr-only">Toggle navigation</span>
             <span class="line" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- remove the live/demo mode toggle block from the Warehouse HQ header
- delete the accompanying CSS that styled the toggle elements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d87cc60b58832d8c18eae79578af8a