### PR TITLE
Add tiered setup and monthly pricing to dental plans

### DIFF
--- a/public/dental/index.html
+++ b/public/dental/index.html
@@ -656,40 +656,67 @@
     <section id="pricing" class="section" data-animate>
       <div class="section-header">
         <h2>Simple plans that scale with your practice</h2>
-        <p>Start with the pilot and expand to multi-location support once you see the impact on missed calls, production, and patient satisfaction.</p>
+        <p>Start with the pilot, then lock in the perfect package as you expand. Every tier bundles onboarding, training, and guaranteed savings on missed calls.</p>
       </div>
       <div class="pricing-grid">
         <div class="price-card">
-          <h3>Pilot</h3>
-          <div class="price">$0<span class="muted"> / 14 days</span></div>
+          <h3>Pilot 🚀</h3>
+          <div class="price">$0<span class="muted"> setup • $0 / 14 days</span></div>
           <ul>
             <li>Full AI phone + SMS sandbox</li>
             <li>Scheduling & waitlist workflows</li>
             <li>Insurance intake logging</li>
             <li>Guided onboarding session</li>
           </ul>
+          <p class="muted">Perfect test drive before you commit.</p>
           <a class="btn primary" href="checkout.html">Start pilot</a>
         </div>
-        <div class="price-card featured">
-          <h3>Growth</h3>
-          <div class="price">$249<span class="muted"> / month</span></div>
+        <div class="price-card">
+          <h3>Starter Smile</h3>
+          <div class="price">$199<span class="muted"> setup • $149 / month</span></div>
           <ul>
             <li>Everything in Pilot</li>
-            <li>Real-time insurance eligibility & co-pay estimates</li>
-            <li>Deposits, review requests, and recall campaigns</li>
-            <li>Up to 3 providers, 2 locations</li>
+            <li>1 provider, 1 location</li>
+            <li>Real-time insurance eligibility checks</li>
+            <li>Missed-call text-back + review requests</li>
           </ul>
+          <p class="muted">For solo dentists who never want to miss a call again.</p>
+          <a class="btn primary" href="checkout.html?plan=starter">Lock in Starter</a>
+        </div>
+        <div class="price-card featured">
+          <h3>Growth Practice</h3>
+          <div class="price">$499<span class="muted"> setup • $349 / month</span></div>
+          <ul>
+            <li>Everything in Starter Smile</li>
+            <li>Up to 3 providers, 2 locations</li>
+            <li>Deposits, recall campaigns & WhatsApp intake</li>
+            <li>Priority waitlist auto-fill rules</li>
+          </ul>
+          <p class="muted">Built for growing teams juggling multiple diaries.</p>
           <a class="btn primary" href="checkout.html?plan=growth">Start 14-day trial</a>
         </div>
         <div class="price-card">
-          <h3>Enterprise</h3>
-          <div class="price">Custom</div>
+          <h3>Premium Care</h3>
+          <div class="price">$999<span class="muted"> setup • $799 / month</span></div>
           <ul>
+            <li>Everything in Growth Practice</li>
+            <li>Unlimited providers, up to 5 locations</li>
+            <li>Multi-location dashboards & co-pay estimates</li>
+            <li>Marketing SMS + review boosts included</li>
+          </ul>
+          <p class="muted">For high-volume practices chasing 5★ reviews and max production.</p>
+          <a class="btn primary" href="checkout.html?plan=premium">Book Premium Onboarding</a>
+        </div>
+        <div class="price-card">
+          <h3>Enterprise DSO</h3>
+          <div class="price">Custom<span class="muted"> setup • Custom monthly</span></div>
+          <ul>
+            <li>Everything in Premium Care</li>
             <li>Multi-site + DSO reporting</li>
             <li>Practice management integrations</li>
-            <li>Dedicated success manager</li>
-            <li>Priority SLA & advanced security</li>
+            <li>Dedicated success manager & priority SLA</li>
           </ul>
+          <p class="muted">For dental groups who want a true partner in scaling.</p>
           <button class="btn ghost" id="btnTalkSales">Talk to sales</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace the dental pricing grid with expanded tiers that pair setup fees with monthly lock-ins
- refresh feature lists and supporting copy to match the dynamic, growth-oriented messaging from warehouse pricing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df06d56974832d87c61f28507de97d