### PR TITLE
Refine dental checkout flows and pricing

### DIFF
--- a/public/dental/checkout.html
+++ b/public/dental/checkout.html
@@ -9,44 +9,116 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
   <style>
     body{margin:0;background:#0b0f19;color:#e6ebf5;font-family:Inter,system-ui,Segoe UI,Roboto,Arial}
+    a{color:#9fb9ff;text-decoration:none}
     .wrap{max-width:760px;margin:0 auto;padding:28px}
-    .card{background:#121829;border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:22px;margin-top:18px}
-    .btn{border:0;border-radius:12px;padding:12px 16px;font-weight:700;background:linear-gradient(180deg,#7c5cff,#5b3bff);color:white;cursor:pointer;display:inline-block;text-decoration:none}
+    .card{background:rgba(18,24,41,0.92);border:1px solid rgba(255,255,255,.12);border-radius:18px;padding:26px;margin-top:18px;box-shadow:0 26px 60px rgba(8,12,27,0.45)}
+    h2{margin:0;font-weight:800;letter-spacing:-0.01em}
     .muted{color:#99a3b3}
+    .plan-name{font-size:20px;font-weight:700;margin:12px 0 6px}
+    .plan-price{font-size:18px;font-weight:600;margin:0 0 16px;color:#c3ccff}
+    .btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:14px 18px;border-radius:14px;border:1px solid rgba(92,125,255,0.5);background:linear-gradient(135deg,#5b3bff,#7c5cff);color:#fff;font-weight:700;cursor:pointer;box-shadow:0 30px 68px rgba(92,125,255,0.35);transition:transform .25s ease, box-shadow .25s ease;position:relative;overflow:hidden}
+    .btn::after{content:"";position:absolute;inset:-16px;border-radius:inherit;background:radial-gradient(circle at 30% 20%,rgba(124,92,255,0.45),transparent 65%);opacity:.85;z-index:-1;transition:opacity .25s ease}
+    .btn:hover{transform:translateY(-2px);box-shadow:0 36px 72px rgba(92,125,255,0.45)}
+    .btn:hover::after{opacity:1}
+    .btn[disabled]{opacity:.6;cursor:not-allowed;transform:none;box-shadow:none}
+    .notice{margin-top:12px;padding:12px 14px;border-radius:12px;background:rgba(37,99,235,0.12);border:1px solid rgba(148,163,184,0.25);color:#cbd5f5;font-size:14px}
   </style>
 </head>
 <body>
   <div class="wrap">
     <h2>Secure Checkout</h2>
+    <p class="muted">Lock in onboarding and your first month below. We’ll redirect you to Stripe for payment.</p>
     <div class="card">
-      <p class="muted">Plan: <b id="planName"></b></p>
-      <p>Click the button below to complete your order via Stripe Checkout.</p>
-      <a id="payBtn" class="btn" href="#" target="_blank" rel="noopener">Pay with Stripe</a>
-      <p class="muted" style="margin-top:10px">You’ll get an email receipt and be redirected to setup. Questions? <a href="mailto:support@delcotechdivision.com">support@delcotechdivision.com</a></p>
-      <p><a class="muted" href="index.html">← Back</a></p>
+      <div id="status" class="notice" style="display:none"></div>
+      <div class="plan-name" id="planName">Loading plan…</div>
+      <div class="plan-price" id="planPrice"></div>
+      <p class="muted" id="planDesc"></p>
+      <button class="btn" id="payBtn" type="button">Launch secure checkout</button>
+      <p class="muted" style="margin-top:16px">Questions? <a href="mailto:support@delcotechdivision.com">support@delcotechdivision.com</a></p>
+      <p style="margin-top:18px"><a class="muted" href="index.html">← Back</a></p>
     </div>
   </div>
 
-<script>
-  // Paste your live Stripe Payment Links here
-  const STRIPE_LINKS = {
-    starter: "https://buy.stripe.com/9B69AT4Yt2nj9x53QpabK03",
-    growth:  "https://buy.stripe.com/4gM6oHez31jf4cL9aJabK04",
-    pro:     "https://buy.stripe.com/4gM14n1Mh1jf9x572BabK05"
-  };
+  <script src="https://js.stripe.com/v3/"></script>
+  <script>
+    const params = new URLSearchParams(location.search);
+    const requestedPlan = (params.get('plan') || 'starter').toLowerCase();
+    const canceled = params.get('canceled');
 
-  const p = new URLSearchParams(location.search).get('plan') || 'starter';
-  const labels = {starter:'Starter ($149/mo)', growth:'Growth ($249/mo)', pro:'Pro ($449/mo)'};
-  document.getElementById('planName').textContent = labels[p] || labels.starter;
+    const statusEl = document.getElementById('status');
+    const planNameEl = document.getElementById('planName');
+    const planPriceEl = document.getElementById('planPrice');
+    const planDescEl = document.getElementById('planDesc');
+    const payBtn = document.getElementById('payBtn');
 
-  const a = document.getElementById('payBtn');
-  a.href = STRIPE_LINKS[p] || '#';
-  a.addEventListener('click', (e) => {
-    if(a.href === '#'){
-      e.preventDefault();
-      alert('Add your Stripe Checkout link in STRIPE_LINKS before going live.');
+    if(canceled){
+      statusEl.textContent = 'Checkout was canceled. You can reopen it below when you are ready.';
+      statusEl.style.display = 'block';
     }
-  });
-</script>
+
+    let stripeClient = null;
+    let selectedPlan = null;
+
+    function formatCurrency(amount){
+      return new Intl.NumberFormat('en-US', { style:'currency', currency:'USD', maximumFractionDigits:0 }).format(amount);
+    }
+
+    async function launchCheckout(){
+      if(!selectedPlan) return;
+      payBtn.disabled = true;
+      try{
+        const res = await fetch('/api/dental/checkout', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ plan: selectedPlan.slug })
+        });
+        const data = await res.json().catch(() => ({}));
+        if(!res.ok){
+          throw new Error(data?.error || 'checkout_unavailable');
+        }
+        if(data.url){
+          window.location.href = data.url;
+          return;
+        }
+        if(data.id && stripeClient){
+          await stripeClient.redirectToCheckout({ sessionId: data.id });
+          return;
+        }
+        throw new Error('missing_checkout_url');
+      }catch(err){
+        console.error('dental checkout failed', err);
+        alert('Unable to open Stripe checkout right now. Please try again or contact support.');
+      }finally{
+        payBtn.disabled = false;
+      }
+    }
+
+    payBtn.addEventListener('click', launchCheckout);
+
+    fetch('/config').then(r => r.json()).then(cfg => {
+      if(cfg?.stripePk){
+        stripeClient = Stripe(cfg.stripePk);
+      }
+      const plans = Array.isArray(cfg?.dentalPlans) ? cfg.dentalPlans : [];
+      selectedPlan = plans.find(p => p.slug === requestedPlan) || plans[0];
+
+      if(!selectedPlan){
+        planNameEl.textContent = 'Plan not found';
+        planPriceEl.textContent = '';
+        planDescEl.textContent = 'Reach out to support and we will get you the correct pricing link.';
+        payBtn.disabled = true;
+        return;
+      }
+
+      planNameEl.textContent = selectedPlan.name;
+      planPriceEl.textContent = `${formatCurrency(selectedPlan.setup)} setup • ${formatCurrency(selectedPlan.monthly)} / month`;
+      planDescEl.textContent = selectedPlan.description || '';
+      payBtn.textContent = `Secure ${selectedPlan.name}`;
+    }).catch(() => {
+      planNameEl.textContent = 'Plan unavailable';
+      planDescEl.textContent = 'We could not load pricing details. Refresh or contact support.';
+      payBtn.disabled = true;
+    });
+  </script>
 </body>
 </html>

--- a/public/dental/index.html
+++ b/public/dental/index.html
@@ -146,7 +146,8 @@
       margin:24px 0 16px;
     }
     .btn{
-      border:0;
+      position:relative;
+      border:1px solid rgba(37,99,235,0.25);
       border-radius:16px;
       padding:13px 20px;
       font-weight:700;
@@ -156,21 +157,44 @@
       align-items:center;
       justify-content:center;
       gap:10px;
-      transition:transform .25s ease, box-shadow .25s ease, background .25s ease;
+      transition:transform .25s ease, box-shadow .25s ease, background .25s ease, border-color .25s ease;
+      box-shadow:0 22px 48px rgba(37,99,235,0.18);
+      background:rgba(255,255,255,0.78);
+      color:var(--ink);
+      z-index:0;
+      overflow:hidden;
+      backdrop-filter:blur(8px) saturate(130%);
+      -webkit-backdrop-filter:blur(8px) saturate(130%);
+    }
+    .btn::after{
+      content:"";
+      position:absolute;
+      inset:-12px;
+      border-radius:inherit;
+      background:radial-gradient(circle at 30% 20%, rgba(34,211,238,0.32), transparent 60%);
+      opacity:0.85;
+      z-index:-1;
+      transition:opacity .3s ease;
     }
     .btn.primary{
       background:linear-gradient(130deg, var(--brand) 0%, var(--brand-dark) 70%);
       color:#fff;
-      box-shadow:0 18px 36px rgba(37,99,235,0.25);
+      border-color:rgba(29,78,216,0.45);
+      box-shadow:0 26px 56px rgba(37,99,235,0.32);
     }
-    .btn.primary:hover{transform:translateY(-2px);box-shadow:0 26px 48px rgba(37,99,235,0.32)}
+    .btn.primary::after{
+      background:radial-gradient(circle at 50% 10%, rgba(96,165,250,0.45), transparent 65%);
+      opacity:1;
+    }
+    .btn.primary:hover{transform:translateY(-2px);box-shadow:0 30px 60px rgba(37,99,235,0.38)}
     .btn.ghost{
-      background:rgba(255,255,255,0.7);
-      border:1px solid rgba(15,23,42,0.1);
+      background:rgba(241,245,249,0.82);
+      border:1px solid rgba(148,163,184,0.35);
       color:var(--ink);
-      box-shadow:0 10px 26px rgba(15,23,42,0.08);
+      box-shadow:0 20px 46px rgba(15,23,42,0.16);
     }
-    .btn.ghost:hover{transform:translateY(-2px);background:#fff}
+    .btn.ghost:hover{transform:translateY(-2px);background:rgba(255,255,255,0.9)}
+    .btn:hover::after{opacity:1}
 
     .hero-stats{
       display:flex;
@@ -350,12 +374,26 @@
       transition:all .2s ease;
       font-weight:600;
       color:var(--ink);
+      box-shadow:0 18px 36px rgba(37,99,235,0.12);
+      position:relative;
+      overflow:hidden;
     }
-    .slot:hover{border-color:var(--brand);box-shadow:0 0 0 3px rgba(37,99,235,0.12)}
-    .slot.active{background:linear-gradient(130deg, rgba(37,99,235,0.95), rgba(29,78,216,0.9));color:#fff;border-color:transparent;box-shadow:0 14px 30px rgba(37,99,235,0.24)}
+    .slot::after{
+      content:"";
+      position:absolute;
+      inset:-16px;
+      border-radius:inherit;
+      background:radial-gradient(circle at 35% 10%, rgba(96,165,250,0.25), transparent 60%);
+      opacity:0.7;
+      z-index:-1;
+      transition:opacity .25s ease;
+    }
+    .slot:hover{border-color:var(--brand);box-shadow:0 0 0 3px rgba(37,99,235,0.18)}
+    .slot:hover::after{opacity:1}
+    .slot.active{background:linear-gradient(130deg, rgba(37,99,235,0.95), rgba(29,78,216,0.9));color:#fff;border-color:transparent;box-shadow:0 20px 42px rgba(37,99,235,0.3)}
     .muted{color:var(--muted)}
 
-    .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}
+    .pricing-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:20px}
     @media(max-width:1024px){.pricing-grid{grid-template-columns:repeat(2,1fr)}}
     @media(max-width:720px){.pricing-grid{grid-template-columns:1fr}}
     .price-card{padding:28px;border-radius:var(--radius);background:#ffffff;border:1px solid rgba(15,23,42,0.08);box-shadow:var(--shadow);display:flex;flex-direction:column;gap:16px;position:relative;overflow:hidden}
@@ -424,8 +462,8 @@
         <h1 class="hero-title">Human-like AI phone reception that books, texts, and verifies insurance for you.</h1>
         <p class="hero-sub">Answer every call with a natural voice assistant that follows your protocols, fills schedules from the waitlist, texts confirmations, and runs real insurance coverage checks—so your front desk can focus on patient experience.</p>
         <div class="cta-row">
-          <a class="btn primary" href="checkout.html">Start free pilot</a>
-          <button class="btn ghost" id="ctaDemo">Book 15-minute demo</button>
+          <button class="btn primary" type="button" data-checkout="starter">Activate AI receptionist</button>
+          <button class="btn ghost" type="button" id="ctaDemo">Book 15-minute demo</button>
           <a class="btn ghost" href="tel:+14848614068">Hear the AI receptionist</a>
         </div>
         <div class="hero-stats">
@@ -555,7 +593,7 @@
               <div class="step">Availability</div>
               <div class="step">Confirm</div>
             </div>
-            <p class="muted">Need to go deeper? <button class="btn ghost" id="ctaPilot" style="margin-top:10px">Start guided pilot</button></p>
+            <p class="muted">Need to go deeper? We’ll map your workflows during a guided onboarding call.</p>
           </div>
           <div>
             <div id="step1">
@@ -643,8 +681,8 @@
               <h3 style="margin-top:0">✅ Demo booking created</h3>
               <p class="muted" id="summary"></p>
               <div class="cta-row" style="margin-top:20px">
-                <a class="btn primary" href="checkout.html?plan=starter">Start your 14-day trial</a>
-                <button class="btn ghost" onclick="resetDemo()">Book another</button>
+                <button class="btn primary" type="button" data-checkout="starter">Activate Starter Smile</button>
+                <button class="btn ghost" type="button" onclick="resetDemo()">Book another</button>
               </div>
               <small class="muted">This is a demo—no SMS is being sent. In production, a confirmation text + calendar invite goes out instantly.</small>
             </div>
@@ -656,36 +694,28 @@
     <section id="pricing" class="section" data-animate>
       <div class="section-header">
         <h2>Simple plans that scale with your practice</h2>
-        <p>Start with the pilot, then lock in the perfect package as you expand. Every tier bundles onboarding, training, and guaranteed savings on missed calls.</p>
+        <p>Each package includes guided onboarding, insurance verification, and AI reception tuned to your exact scripts.</p>
       </div>
       <div class="pricing-grid">
         <div class="price-card">
-          <h3>Pilot 🚀</h3>
-          <div class="price">$0<span class="muted"> setup • $0 / 14 days</span></div>
-          <ul>
-            <li>Full AI phone + SMS sandbox</li>
-            <li>Scheduling & waitlist workflows</li>
-            <li>Insurance intake logging</li>
-            <li>Guided onboarding session</li>
-          </ul>
-          <p class="muted">Perfect test drive before you commit.</p>
-          <a class="btn primary" href="checkout.html">Start pilot</a>
-        </div>
-        <div class="price-card">
           <h3>Starter Smile</h3>
-          <div class="price">$199<span class="muted"> setup • $149 / month</span></div>
+          <div class="price" data-plan-price="starter">
+            <span data-role="setup">$199 setup</span> • <span data-role="monthly">$149 / month</span>
+          </div>
           <ul>
-            <li>Everything in Pilot</li>
+            <li>AI phone + SMS reception included</li>
             <li>1 provider, 1 location</li>
             <li>Real-time insurance eligibility checks</li>
             <li>Missed-call text-back + review requests</li>
           </ul>
           <p class="muted">For solo dentists who never want to miss a call again.</p>
-          <a class="btn primary" href="checkout.html?plan=starter">Lock in Starter</a>
+          <button class="btn primary" type="button" data-checkout="starter">Activate Starter Smile</button>
         </div>
         <div class="price-card featured">
           <h3>Growth Practice</h3>
-          <div class="price">$499<span class="muted"> setup • $349 / month</span></div>
+          <div class="price" data-plan-price="growth">
+            <span data-role="setup">$499 setup</span> • <span data-role="monthly">$349 / month</span>
+          </div>
           <ul>
             <li>Everything in Starter Smile</li>
             <li>Up to 3 providers, 2 locations</li>
@@ -693,11 +723,13 @@
             <li>Priority waitlist auto-fill rules</li>
           </ul>
           <p class="muted">Built for growing teams juggling multiple diaries.</p>
-          <a class="btn primary" href="checkout.html?plan=growth">Start 14-day trial</a>
+          <button class="btn primary" type="button" data-checkout="growth">Launch Growth Practice</button>
         </div>
         <div class="price-card">
           <h3>Premium Care</h3>
-          <div class="price">$999<span class="muted"> setup • $799 / month</span></div>
+          <div class="price" data-plan-price="premium">
+            <span data-role="setup">$999 setup</span> • <span data-role="monthly">$799 / month</span>
+          </div>
           <ul>
             <li>Everything in Growth Practice</li>
             <li>Unlimited providers, up to 5 locations</li>
@@ -705,7 +737,7 @@
             <li>Marketing SMS + review boosts included</li>
           </ul>
           <p class="muted">For high-volume practices chasing 5★ reviews and max production.</p>
-          <a class="btn primary" href="checkout.html?plan=premium">Book Premium Onboarding</a>
+          <button class="btn primary" type="button" data-checkout="premium">Secure Premium Care</button>
         </div>
         <div class="price-card">
           <h3>Enterprise DSO</h3>
@@ -717,7 +749,7 @@
             <li>Dedicated success manager & priority SLA</li>
           </ul>
           <p class="muted">For dental groups who want a true partner in scaling.</p>
-          <button class="btn ghost" id="btnTalkSales">Talk to sales</button>
+          <button class="btn ghost" type="button" id="btnTalkSales">Book 15-minute demo</button>
         </div>
       </div>
     </section>
@@ -751,6 +783,7 @@
 
   <link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">
   <script src="https://assets.calendly.com/assets/external/widget.js" async></script>
+  <script src="https://js.stripe.com/v3/"></script>
   <script>
     document.getElementById('yr').textContent = new Date().getFullYear();
 
@@ -778,9 +811,86 @@
       }
     }
     document.getElementById('ctaDemo').onclick = openCalendly;
-    document.getElementById('btnTalkSales').onclick = openCalendly;
-    const pilotBtn = document.getElementById('ctaPilot');
-    if(pilotBtn) pilotBtn.addEventListener('click', () => window.location.href = 'checkout.html');
+    const talkSalesBtn = document.getElementById('btnTalkSales');
+    if(talkSalesBtn) talkSalesBtn.onclick = openCalendly;
+
+    let stripeClient = null;
+
+    function formatCurrency(amount){
+      return new Intl.NumberFormat('en-US', { style:'currency', currency:'USD', maximumFractionDigits:0 }).format(amount);
+    }
+
+    async function startDentalCheckout(plan, source){
+      if(!plan) return;
+      const btn = source instanceof HTMLElement ? source : null;
+      if(btn){
+        btn.disabled = true;
+        btn.dataset.loading = '1';
+      }
+
+      try{
+        const res = await fetch('/api/dental/checkout', {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({ plan })
+        });
+        const data = await res.json().catch(() => ({}));
+        if(!res.ok){
+          throw new Error(data?.error || 'checkout_unavailable');
+        }
+
+        if(data.url){
+          window.location.href = data.url;
+          return;
+        }
+
+        if(data.id && stripeClient){
+          await stripeClient.redirectToCheckout({ sessionId: data.id });
+          return;
+        }
+
+        throw new Error('missing_checkout_url');
+      }catch(err){
+        console.error('Unable to start checkout', err);
+        alert('Unable to open Stripe checkout right now. Please try again or contact support.');
+      }finally{
+        if(btn){
+          btn.disabled = false;
+          delete btn.dataset.loading;
+        }
+      }
+    }
+
+    window.startDentalCheckout = startDentalCheckout;
+
+    fetch('/config').then(r => r.json()).then(cfg => {
+      if(cfg?.stripePk){
+        stripeClient = Stripe(cfg.stripePk);
+      }
+      if(Array.isArray(cfg?.dentalPlans)){
+        cfg.dentalPlans.forEach(plan => {
+          const priceEl = document.querySelector(`[data-plan-price="${plan.slug}"]`);
+          if(priceEl){
+            const setupEl = priceEl.querySelector('[data-role="setup"]');
+            const monthlyEl = priceEl.querySelector('[data-role="monthly"]');
+            if(setupEl && typeof plan.setup === 'number'){
+              setupEl.textContent = `${formatCurrency(plan.setup)} setup`;
+            }
+            if(monthlyEl && typeof plan.monthly === 'number'){
+              monthlyEl.textContent = `${formatCurrency(plan.monthly)} / month`;
+            }
+          }
+        });
+      }
+    }).catch(() => {});
+
+    document.querySelectorAll('[data-checkout]').forEach(el => {
+      el.addEventListener('click', e => {
+        e.preventDefault();
+        const plan = el.getAttribute('data-checkout');
+        startDentalCheckout(plan, el);
+      });
+    });
 
     // ===== Demo flow =====
     let selectedSlot = null;


### PR DESCRIPTION
## Summary
- add reusable dental plan metadata on the server and expose it through `/config`
- implement a dedicated `/api/dental/checkout` Stripe session creator for plan-specific pricing
- refresh the dental landing + checkout pages to remove pilot language, add glow styling, hook Calendly, and trigger the new dynamic checkout flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df0a38c450832d9324f2d17b5c4f86