### PR TITLE
Fix ElevenLabs TTS proxy on Node <18

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,11 @@ const stripe = Stripe(process.env.STRIPE_SECRET_KEY || '');
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || '' }); // 👈 NEW
 const APP_BASE_URL = process.env.PUBLIC_BASE_URL || 'https://www.delcotechdivision.com';
 
+const fetch = global.fetch || require('node-fetch');
+if (!global.fetch) {
+  global.fetch = fetch;
+}
+
 const { twiml: { VoiceResponse } } = require('twilio');
 const { sendSMS, client: twilioClient } = require('./services/twilioClient');
 const { upsertByPhone, findAll } = require('./services/sheets');

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "node-cron": "^3.0.3",
         "openai": "^4.104.0",
         "stripe": "^18.4.0",
-        "twilio": "^5.3.3"
+        "twilio": "^5.3.3",
+        "node-fetch": "^2.7.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "node-cron": "^3.0.3",
     "openai": "^4.104.0",
     "stripe": "^18.4.0",
-    "twilio": "^5.3.3"
+    "twilio": "^5.3.3",
+    "node-fetch": "^2.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.0"


### PR DESCRIPTION
## Summary
- add a node-fetch fallback so ElevenLabs TTS proxy works on Node runtimes without native fetch
- declare node-fetch as a direct dependency to ensure availability across environments

## Testing
- npm install *(fails: registry returned 403 Forbidden for mongodb package)*

------
https://chatgpt.com/codex/tasks/task_e_68dfaf392d7c832d830c286d145472e4