### PR TITLE
Add diagnostic logging around SMS delivery flows

### DIFF
--- a/services/twilioClient.js
+++ b/services/twilioClient.js
@@ -2,14 +2,60 @@ require('dotenv').config();
 const twilio = require('twilio');
 const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
 
-async function sendSMS(to, body) {
+function redactBody(value, max = 320) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max)}… (${value.length - max} more chars)`;
+}
+
+async function sendSMS(to, body, context = {}) {
   const payload = { to, body };
   if (process.env.MESSAGING_SERVICE_SID) {
     payload.messagingServiceSid = process.env.MESSAGING_SERVICE_SID;
   } else {
     payload.from = process.env.TWILIO_NUMBER;
   }
-  return client.messages.create(payload);
+
+  const attemptLog = {
+    timestamp: new Date().toISOString(),
+    to,
+    usingMessagingService: Boolean(process.env.MESSAGING_SERVICE_SID),
+    from: payload.from || null,
+    context,
+    bodyPreview: redactBody(body, 160),
+  };
+  console.info('[SMS] Attempting to send message', attemptLog);
+
+  try {
+    const message = await client.messages.create(payload);
+    console.info('[SMS] Message queued', {
+      timestamp: new Date().toISOString(),
+      sid: message?.sid,
+      status: message?.status,
+      to: message?.to,
+      from: message?.from,
+      messagingServiceSid: message?.messagingServiceSid || payload.messagingServiceSid || null,
+      context,
+    });
+    return message;
+  } catch (error) {
+    console.error('[SMS] Message failed', {
+      timestamp: new Date().toISOString(),
+      error: {
+        message: error?.message,
+        code: error?.code,
+        status: error?.status,
+        moreInfo: error?.moreInfo,
+      },
+      payload: { ...payload, body: redactBody(payload.body) },
+      context,
+    });
+    throw error;
+  }
 }
 
 module.exports = { client, sendSMS };


### PR DESCRIPTION
## Summary
- add structured logging to the Twilio SMS helper so each attempt logs payload details, context, and API outcomes
- propagate contextual metadata from SMS entry points (cold caller link, text link API, missed call follow ups, review reminders, simulation) to aid debugging

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e011e62778832d8d4625345e93eff4