### PR TITLE
Attach real estate cold caller image to SMS link

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ fs.mkdirSync(TTS_CACHE_DIR, { recursive: true });
 
 const COLD_CALLER_SMS_LINK = process.env.COLD_CALLER_SMS_LINK
   || 'https://www.delcotechdivision.com/real-estate-cold-caller.html';
+const COLD_CALLER_SMS_MEDIA = `${APP_BASE_URL}/image/${encodeURIComponent('lifelike AI cold caller.png')}`;
 
 const ELEVENLABS_MODEL_ID = process.env.ELEVENLABS_MODEL_ID || 'eleven_multilingual_v2';
 const FALLBACK_ELEVENLABS_VOICE_ID = '21m00Tcm4TlvDq8ikWAM';
@@ -436,7 +437,10 @@ async function sendColdCallerLink(toNumber, callSid) {
         source: 'cold_caller_auto_link',
         callSid: callSid || null,
         originalTo: toNumber,
-      }
+      },
+      {
+        mediaUrl: [COLD_CALLER_SMS_MEDIA],
+      },
     );
     if (callSid) {
       callSmsTracker.set(callSid, Date.now());

--- a/services/twilioClient.js
+++ b/services/twilioClient.js
@@ -46,11 +46,11 @@ function redactBody(value, max = 320) {
   return `${value.slice(0, max)}… (${value.length - max} more chars)`;
 }
 
-async function sendSMS(to, body, context = {}) {
-  const payload = { to, body };
+async function sendSMS(to, body, context = {}, twilioOptions = {}) {
+  const payload = { to, body, ...twilioOptions };
   if (process.env.MESSAGING_SERVICE_SID) {
     payload.messagingServiceSid = process.env.MESSAGING_SERVICE_SID;
-  } else {
+  } else if (!payload.from) {
     payload.from = process.env.TWILIO_NUMBER;
   }
 
@@ -67,6 +67,11 @@ async function sendSMS(to, body, context = {}) {
     from: maskPhone(payload.from || null),
     context: maskContext(context),
     bodyPreview: redactBody(body, 160),
+    mediaCount: Array.isArray(payload.mediaUrl)
+      ? payload.mediaUrl.length
+      : payload.mediaUrl
+        ? 1
+        : 0,
   };
   console.info('[SMS] Attempting to send message', attemptLog);
 


### PR DESCRIPTION
## Summary
- include the lifelike cold caller marketing image when sending the real estate cold caller SMS link
- extend the Twilio SMS helper to accept optional media attachments and log media usage for observability

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e03cd1c96c832d8fb9d6fe4550bd34