### PR TITLE
Adjust region transition pacing and symbol reveal

### DIFF
--- a/public/multifaith-giving-platform.html
+++ b/public/multifaith-giving-platform.html
@@ -315,8 +315,8 @@
       filter: brightness(0%);
       -webkit-mask-image: var(--transition-mask-image, none);
       mask-image: var(--transition-mask-image, none);
-      -webkit-mask-size: 12%;
-      mask-size: 12%;
+      -webkit-mask-size: 6%;
+      mask-size: 6%;
       -webkit-mask-position: center;
       mask-position: center;
       -webkit-mask-repeat: no-repeat;
@@ -402,10 +402,15 @@
     @keyframes regionSceneReveal {
       0% {
         filter: brightness(0%);
+        -webkit-mask-size: 6%;
+        mask-size: 6%;
+      }
+      12% {
+        filter: brightness(55%);
         -webkit-mask-size: 12%;
         mask-size: 12%;
       }
-      20% {
+      28% {
         filter: brightness(100%);
       }
       100% {
@@ -1900,7 +1905,7 @@
     } else {
       nextScene.style.setProperty('--transition-mask-image', 'none');
     }
-    const duration = 1400;
+    const duration = 1800;
     overlay.style.setProperty('--transition-duration', `${duration}ms`);
     updateTransitionOverlayForIndex(currentIndex);
     state.preloadedSlideId = nextSlideData.id;


### PR DESCRIPTION
## Summary
- shrink the transition mask's initial size so the faith symbol appears centered before expanding
- ease in the reveal animation with intermediate brightness steps for a smoother effect
- lengthen the transition duration to slow the slide handoff pacing

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68e267826ec8832d9d842ba4035f7e7f