### PR TITLE
Improve mobile layout for multifaith giving page

### DIFF
--- a/public/multifaith-giving-platform.html
+++ b/public/multifaith-giving-platform.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"/>
   <title>Multi-Faith Giving Platform</title>
   <meta name="description" content="Give and manage faith-specific donations across every region with a single secure platform."/>
   <style>
@@ -32,6 +32,7 @@
       min-height: 100vh;
       display: flex;
       flex-direction: column;
+      overflow-x: hidden;
     }
 
     img {
@@ -97,6 +98,8 @@
       position: relative;
       overflow: hidden;
       transition: box-shadow 0.2s ease, transform 0.2s ease;
+      min-height: 48px;
+      touch-action: manipulation;
     }
 
     .btn.liquid {
@@ -687,7 +690,7 @@
       background: rgba(5, 10, 25, 0.86);
       color: #f6f9ff;
       padding: 12px;
-      font-size: 15px;
+      font-size: 16px;
       font-family: inherit;
     }
 
@@ -947,6 +950,149 @@
       color: var(--muted);
       font-size: 14px;
       border-top: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    @media (max-width: 900px) {
+      .nav {
+        padding: 16px;
+        gap: 14px;
+      }
+
+      .inline-actions {
+        width: 100%;
+        justify-content: flex-start;
+      }
+    }
+
+    @media (max-width: 720px) {
+      main {
+        padding: 20px 16px 70px;
+        gap: 42px;
+      }
+
+      .hero {
+        gap: 18px;
+      }
+
+      .hero h1 {
+        font-size: clamp(30px, 9vw, 44px);
+      }
+
+      .hero p {
+        font-size: 16px;
+        margin: 12px 0 20px;
+      }
+
+      .hero-media {
+        border-radius: 22px;
+        min-height: 220px;
+      }
+
+      .hero-list li {
+        font-size: 15px;
+        align-items: flex-start;
+      }
+
+      .section-head {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 16px;
+      }
+
+      .region-slide {
+        padding: 20px;
+        grid-template-columns: 1fr;
+      }
+
+      .region-meta h3 {
+        font-size: 22px;
+      }
+
+      .currency-row {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .sector-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .community-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 600px) {
+      header {
+        position: sticky;
+      }
+
+      .nav {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+      }
+
+      .brand {
+        justify-content: space-between;
+        width: 100%;
+      }
+
+      .inline-actions,
+      .nav .btn,
+      .inline-actions .btn {
+        width: 100%;
+      }
+
+      .inline-actions {
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .btn {
+        width: 100%;
+      }
+
+      .form-card {
+        padding: 20px;
+      }
+
+      .form-actions {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+      }
+
+      .form-actions .btn {
+        min-width: 0;
+      }
+
+      .community-actions {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .community-actions .btn {
+        width: 100%;
+      }
+
+      .slider-controls {
+        padding: 0 16px;
+        bottom: 12px;
+      }
+
+      .slider-btn {
+        width: 36px;
+        height: 36px;
+      }
+
+      .slider-dots {
+        bottom: 12px;
+      }
+
+      footer {
+        padding: 30px 0 40px;
+      }
     }
 
     .result-block {


### PR DESCRIPTION
## Summary
- prevent zooming on the multifaith giving page and enlarge interactive controls for touch
- add responsive breakpoints so navigation, forms, and content cards stack cleanly on small screens
- adjust typography and spacing to keep inputs and copy legible on mobile widths

## Testing
- Not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68e284102fa4832d90f73d4da75578ab