### PR TITLE
Restyle currency icons to match reference layout

### DIFF
--- a/public/multifaith-giving-platform.html
+++ b/public/multifaith-giving-platform.html
@@ -439,10 +439,11 @@
     }
 
     .currency-row {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: flex-start;
-      gap: 12px;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      align-items: center;
+      column-gap: 20px;
+      row-gap: 12px;
       margin: 18px 0 0;
       font-size: 15px;
       color: #d9e3ff;
@@ -453,7 +454,7 @@
       letter-spacing: 0.3px;
       color: #f0f4ff;
       flex-shrink: 0;
-      line-height: 1.4;
+      line-height: 1.3;
     }
 
     .currency-list {
@@ -462,29 +463,38 @@
       list-style: none;
       display: flex;
       flex-wrap: wrap;
-      gap: 10px;
+      align-items: center;
+      gap: 14px;
     }
 
     .currency-item {
       display: inline-flex;
       align-items: center;
-      gap: 10px;
-      padding: 8px 12px;
+      gap: 12px;
+      padding: 10px 16px 10px 12px;
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.05);
-      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: rgba(21, 32, 72, 0.72);
+      border: 1px solid rgba(139, 162, 255, 0.25);
+      box-shadow: 0 10px 30px rgba(8, 18, 54, 0.35);
       font-size: 13px;
-      letter-spacing: 0.3px;
+      letter-spacing: 0.4px;
       text-transform: uppercase;
-      color: #e5edff;
+      color: #f4f7ff;
     }
 
     .currency-item img {
-      width: 32px;
-      height: 20px;
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
       object-fit: cover;
-      border-radius: 6px;
-      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.35);
+      box-shadow: 0 6px 14px rgba(12, 26, 68, 0.45);
+      border: 2px solid rgba(255, 255, 255, 0.2);
+    }
+
+    .currency-item span {
+      display: block;
+      font-weight: 700;
+      letter-spacing: 0.5px;
     }
 
     .region-meta ul {


### PR DESCRIPTION
## Summary
- align the currency row label and icon list so the header and badges share the same baseline, mirroring the reference layout
- refresh the currency badge styling with circular imagery, updated spacing, and stronger contrast to match the reference UI treatment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e29c94a014832d9e5a5f321f2cc2d1