### PR TITLE
Refresh multifaith giving page with light theme and layout fixes

### DIFF
--- a/public/multifaith-giving-platform.html
+++ b/public/multifaith-giving-platform.html
@@ -7,16 +7,16 @@
   <meta name="description" content="Give and manage faith-specific donations across every region with a single secure platform."/>
   <style>
     :root {
-      --bg: #050918;
-      --bg-soft: #0a1124;
-      --bg-glass: rgba(255, 255, 255, 0.05);
-      --card: rgba(9, 18, 40, 0.82);
-      --ink: #f5f7ff;
-      --muted: #9ea8d6;
-      --accent: #7c4dff;
-      --accent-2: #37c79a;
-      --accent-3: #4a8bff;
-      --danger: #ff5684;
+      --bg: #f8f6f1;
+      --bg-soft: #ffffff;
+      --bg-glass: rgba(255, 255, 255, 0.75);
+      --card: #ffffff;
+      --ink: #1f2933;
+      --muted: #5f6b7d;
+      --accent: #d4a24c;
+      --accent-2: #7a9d92;
+      --accent-3: #e2c184;
+      --danger: #d9534f;
       font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
     }
 
@@ -26,7 +26,7 @@
 
     body {
       margin: 0;
-      background: radial-gradient(circle at top, rgba(76, 71, 143, 0.45), transparent 60%), var(--bg);
+      background: radial-gradient(circle at top, rgba(255, 255, 255, 0.92), transparent 55%), var(--bg);
       color: var(--ink);
       font: 16px/1.6 "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
       min-height: 100vh;
@@ -41,16 +41,20 @@
     }
 
     a {
-      color: #cde0ff;
+      color: var(--accent);
+    }
+
+    a:hover {
+      color: var(--accent-2);
     }
 
     header {
       position: sticky;
       top: 0;
       z-index: 100;
-      background: linear-gradient(180deg, rgba(5, 9, 24, 0.92), rgba(5, 9, 24, 0.6));
-      backdrop-filter: blur(12px);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.94);
+      backdrop-filter: blur(10px);
+      border-bottom: 1px solid rgba(31, 41, 55, 0.08);
     }
 
     .nav {
@@ -62,6 +66,7 @@
       gap: 18px;
       justify-content: space-between;
       flex-wrap: wrap;
+      color: var(--ink);
     }
 
     .brand {
@@ -71,6 +76,7 @@
       font-weight: 800;
       letter-spacing: 0.6px;
       text-transform: uppercase;
+      color: var(--ink);
     }
 
     .brand span {
@@ -92,8 +98,8 @@
       font-weight: 700;
       color: #fff;
       background: linear-gradient(135deg, var(--accent), var(--accent-3));
-      border: 1px solid rgba(255, 255, 255, 0.16);
-      box-shadow: 0 16px 40px rgba(76, 71, 143, 0.4);
+      border: 1px solid rgba(212, 162, 76, 0.35);
+      box-shadow: 0 10px 26px rgba(212, 162, 76, 0.25);
       cursor: pointer;
       position: relative;
       overflow: hidden;
@@ -105,9 +111,9 @@
     .btn.liquid {
       padding: 0;
       border-radius: 10px;
-      background: rgba(10, 17, 36, 0.7);
-      border: 1px solid rgba(114, 147, 255, 0.65);
-      box-shadow: 0 12px 30px rgba(114, 147, 255, 0.28);
+      background: rgba(255, 255, 255, 0.85);
+      border: 1px solid rgba(212, 162, 76, 0.5);
+      box-shadow: 0 12px 30px rgba(225, 192, 128, 0.3);
       text-transform: uppercase;
       letter-spacing: 0.6px;
       min-width: 0;
@@ -117,17 +123,17 @@
       position: relative;
       z-index: 1;
       padding: 14px 36px;
-      color: #fff;
+      color: var(--ink);
     }
 
     .btn.liquid .liquid {
       position: absolute;
       inset: -80px 0 auto;
       height: 220px;
-      background: linear-gradient(135deg, rgba(114, 147, 255, 0.95), rgba(110, 247, 255, 0.75), rgba(255, 140, 214, 0.9));
+      background: linear-gradient(135deg, rgba(212, 162, 76, 0.65), rgba(226, 193, 132, 0.7), rgba(122, 157, 146, 0.65));
       background-size: 200% 200%;
       animation: holographicFlow 8s ease-in-out infinite;
-      box-shadow: inset 0 0 50px rgba(0, 0, 0, 0.65);
+      box-shadow: inset 0 0 40px rgba(255, 255, 255, 0.45);
       z-index: 0;
       transition: 0.6s ease;
     }
@@ -145,15 +151,15 @@
     }
 
     .btn.liquid .liquid::after {
-      background: rgba(18, 18, 32, 0.92);
-      box-shadow: 0 0 12px 6px rgba(114, 147, 255, 0.75), inset 0 0 8px rgba(114, 147, 255, 0.65);
+      background: rgba(255, 255, 255, 0.76);
+      box-shadow: 0 0 12px 6px rgba(212, 162, 76, 0.45), inset 0 0 8px rgba(226, 193, 132, 0.42);
       animation: animate 5s linear infinite;
       opacity: 0.85;
     }
 
     .btn.liquid .liquid::before {
-      background: rgba(18, 18, 32, 0.55);
-      box-shadow: 0 0 12px rgba(26, 26, 26, 0.4), inset 0 0 6px rgba(26, 26, 26, 0.45);
+      background: rgba(255, 255, 255, 0.35);
+      box-shadow: 0 0 12px rgba(226, 193, 132, 0.4), inset 0 0 6px rgba(226, 193, 132, 0.35);
       animation: animate 7s linear infinite;
     }
 
@@ -162,15 +168,20 @@
     }
 
     .btn.liquid:hover {
-      box-shadow: 0 0 8px rgba(114, 147, 255, 0.85), inset 0 0 6px rgba(114, 147, 255, 0.85);
+      box-shadow: 0 0 8px rgba(212, 162, 76, 0.6), inset 0 0 6px rgba(212, 162, 76, 0.55);
       transform: translateY(-2px);
     }
 
     .btn.ghost {
-      background: transparent;
-      color: #dbe2ff;
-      border-color: rgba(255, 255, 255, 0.16);
+      background: #fff;
+      color: var(--accent);
+      border-color: rgba(212, 162, 76, 0.35);
       box-shadow: none;
+    }
+
+    .btn.ghost:hover {
+      background: rgba(212, 162, 76, 0.1);
+      color: var(--ink);
     }
 
     main {
@@ -209,7 +220,7 @@
       border-radius: 30px;
       overflow: hidden;
       background: var(--card);
-      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+      box-shadow: 0 18px 44px rgba(31, 41, 55, 0.15);
       min-height: 260px;
     }
 
@@ -217,7 +228,7 @@
       content: "";
       position: absolute;
       inset: 0;
-      background: radial-gradient(circle at top right, rgba(124, 77, 255, 0.32), transparent 50%);
+      background: radial-gradient(circle at top right, rgba(212, 162, 76, 0.28), transparent 55%);
       pointer-events: none;
     }
 
@@ -233,12 +244,12 @@
       display: flex;
       align-items: center;
       gap: 12px;
-      background: rgba(255, 255, 255, 0.05);
+      background: rgba(31, 41, 55, 0.05);
       border-radius: 16px;
       padding: 14px 16px;
-      border: 1px solid rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(31, 41, 55, 0.08);
       font-weight: 600;
-      color: #e9edff;
+      color: var(--ink);
     }
 
     .hero-list li span {
@@ -248,8 +259,8 @@
       width: 34px;
       height: 34px;
       border-radius: 12px;
-      background: rgba(124, 77, 255, 0.2);
-      color: #fff;
+      background: rgba(212, 162, 76, 0.18);
+      color: var(--accent);
       font-weight: 700;
     }
 
@@ -271,9 +282,11 @@
       position: relative;
       background: var(--bg-soft);
       border-radius: 24px;
-      border: 1px solid rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(31, 41, 55, 0.12);
       overflow: hidden;
-      box-shadow: 0 22px 50px rgba(0, 0, 0, 0.45);
+      box-shadow: 0 18px 38px rgba(31, 41, 55, 0.12);
+      max-width: 960px;
+      margin: 0 auto;
     }
 
     .region-track {
@@ -334,18 +347,18 @@
       min-width: 100%;
       padding: 26px;
       display: grid;
-      gap: 22px;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      align-items: center;
+      gap: 20px;
+      grid-template-columns: minmax(280px, 1fr) minmax(260px, 0.8fr);
+      align-items: stretch;
     }
 
     .region-media {
       position: relative;
       width: 100%;
-      height: 260px;
+      height: 220px;
       border-radius: 18px;
       overflow: hidden;
-      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.38);
+      box-shadow: 0 16px 28px rgba(31, 41, 55, 0.18);
     }
 
     .region-media::after {
@@ -353,7 +366,7 @@
       position: absolute;
       inset: 0;
       border-radius: inherit;
-      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+      box-shadow: inset 0 0 0 1px rgba(31, 41, 55, 0.08);
       pointer-events: none;
     }
 
@@ -436,6 +449,7 @@
       margin: 0;
       font-size: 26px;
       font-weight: 800;
+      color: var(--ink);
     }
 
     .currency-row {
@@ -445,13 +459,13 @@
       gap: 22px;
       margin: 18px 0 0;
       font-size: 15px;
-      color: #d9e3ff;
+      color: var(--muted);
     }
 
     .currency-row strong {
       font-size: 15px;
       letter-spacing: 0.35px;
-      color: #f0f4ff;
+      color: var(--accent);
       flex-shrink: 0;
       line-height: 1.4;
       padding-top: 6px;
@@ -472,14 +486,14 @@
       gap: 18px;
       padding: 14px 18px;
       border-radius: 18px;
-      background: linear-gradient(140deg, rgba(31, 52, 130, 0.68), rgba(17, 29, 82, 0.78));
-      border: 1px solid rgba(124, 163, 255, 0.28);
-      box-shadow: 0 18px 32px rgba(5, 10, 35, 0.45);
+      background: #ffffff;
+      border: 1px solid rgba(31, 41, 55, 0.1);
+      box-shadow: 0 12px 24px rgba(31, 41, 55, 0.12);
       font-size: 14px;
       font-weight: 600;
       letter-spacing: 0.4px;
       text-transform: uppercase;
-      color: #f4f7ff;
+      color: var(--ink);
       min-width: 170px;
     }
 
@@ -490,8 +504,8 @@
       max-width: 160px;
       object-fit: contain;
       border-radius: 12px;
-      background: rgba(3, 12, 41, 0.6);
-      box-shadow: 0 10px 24px rgba(0, 0, 0, 0.42);
+      background: rgba(250, 249, 244, 0.9);
+      box-shadow: 0 10px 20px rgba(31, 41, 55, 0.18);
     }
 
     .currency-item span {
@@ -500,7 +514,7 @@
       font-weight: 700;
       letter-spacing: 0.6px;
       text-align: right;
-      color: #f9fbff;
+      color: var(--accent);
     }
 
     .region-meta ul {
@@ -514,10 +528,10 @@
     .region-meta ul li {
       padding: 10px 14px;
       border-radius: 14px;
-      background: rgba(255, 255, 255, 0.05);
-      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: rgba(31, 41, 55, 0.05);
+      border: 1px solid rgba(31, 41, 55, 0.1);
       font-size: 14px;
-      color: #d9e3ff;
+      color: var(--ink);
     }
 
     .faith-identity {
@@ -532,7 +546,7 @@
       letter-spacing: 0.4px;
       text-transform: uppercase;
       font-size: 13px;
-      color: #a4b6ff;
+      color: var(--accent);
     }
 
     .faith-symbol {
@@ -540,7 +554,7 @@
       width: 66px;
       height: 66px;
       border-radius: 22px;
-      background: linear-gradient(135deg, rgba(182, 141, 255, 0.95), rgba(92, 242, 255, 0.8), rgba(255, 176, 218, 0.95));
+      background: linear-gradient(135deg, rgba(245, 214, 148, 0.95), rgba(255, 238, 207, 0.85), rgba(205, 220, 212, 0.9));
       background-size: 200% 200%;
       animation: holographicFlow 9s ease-in-out infinite;
       mask-image: var(--symbol-image);
@@ -551,7 +565,7 @@
       -webkit-mask-repeat: no-repeat;
       -webkit-mask-position: center;
       -webkit-mask-size: 70%;
-      box-shadow: 0 12px 28px rgba(124, 77, 255, 0.45);
+      box-shadow: 0 12px 28px rgba(212, 162, 76, 0.32);
       transition: transform 0.18s ease, box-shadow 0.2s ease;
       transform: perspective(600px) rotateX(0deg) rotateY(0deg);
       transform-style: preserve-3d;
@@ -569,12 +583,12 @@
     }
 
     .faith-symbol:hover {
-      box-shadow: 0 16px 40px rgba(114, 147, 255, 0.6);
+      box-shadow: 0 16px 40px rgba(212, 162, 76, 0.35);
     }
 
     .slider-controls {
       position: absolute;
-      inset: auto 0 14px 0;
+      inset: auto 0 18px 0;
       display: flex;
       justify-content: space-between;
       padding: 0 22px;
@@ -587,20 +601,26 @@
       width: 40px;
       height: 40px;
       border-radius: 12px;
-      border: 1px solid rgba(255, 255, 255, 0.2);
-      background: rgba(9, 18, 40, 0.78);
-      color: #fff;
+      border: 1px solid rgba(31, 41, 55, 0.14);
+      background: rgba(255, 255, 255, 0.9);
+      color: var(--ink);
       display: inline-flex;
       align-items: center;
       justify-content: center;
       font-size: 18px;
       cursor: pointer;
+      box-shadow: 0 6px 16px rgba(31, 41, 55, 0.14);
+    }
+
+    .slider-btn:hover {
+      background: var(--accent);
+      color: #fff;
     }
 
     .slider-dots {
       position: absolute;
       left: 50%;
-      bottom: 20px;
+      bottom: 24px;
       transform: translateX(-50%);
       display: inline-flex;
       gap: 10px;
@@ -611,12 +631,12 @@
       width: 12px;
       height: 12px;
       border-radius: 50%;
-      background: rgba(255, 255, 255, 0.22);
+      background: rgba(31, 41, 55, 0.16);
       cursor: pointer;
     }
 
     .slider-dot.active {
-      background: var(--accent-2);
+      background: var(--accent);
     }
 
     .sector-grid {
@@ -629,22 +649,22 @@
       background: var(--card);
       padding: 20px;
       border-radius: 18px;
-      border: 1px solid rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(31, 41, 55, 0.08);
       display: grid;
       gap: 10px;
-      box-shadow: 0 18px 44px rgba(0, 0, 0, 0.35);
+      box-shadow: 0 12px 28px rgba(31, 41, 55, 0.12);
     }
 
     .sector-card h3 {
       margin: 0;
       font-size: 18px;
       font-weight: 800;
-      color: #f1f4ff;
+      color: var(--ink);
     }
 
     .sector-card p {
       margin: 0;
-      color: #bac3ec;
+      color: var(--muted);
       font-size: 14px;
     }
 
@@ -654,11 +674,11 @@
     }
 
     .form-card {
-      background: linear-gradient(180deg, rgba(124, 77, 255, 0.18), rgba(9, 18, 40, 0.94));
+      background: var(--card);
       border-radius: 24px;
-      border: 1px solid rgba(124, 77, 255, 0.32);
+      border: 1px solid rgba(31, 41, 55, 0.1);
       padding: 24px;
-      box-shadow: 0 24px 58px rgba(0, 0, 0, 0.42);
+      box-shadow: 0 18px 40px rgba(31, 41, 55, 0.14);
     }
 
     .form-card h3 {
@@ -696,22 +716,22 @@
       font-size: 13px;
       font-weight: 600;
       letter-spacing: 0.3px;
-      color: #dce3ff;
+      color: var(--muted);
     }
 
     input, select, textarea {
       margin-top: 6px;
       border-radius: 14px;
-      border: 1px solid rgba(255, 255, 255, 0.18);
-      background: rgba(5, 10, 25, 0.86);
-      color: #f6f9ff;
+      border: 1px solid rgba(31, 41, 55, 0.14);
+      background: rgba(255, 255, 255, 0.9);
+      color: var(--ink);
       padding: 12px;
       font-size: 16px;
       font-family: inherit;
     }
 
     input:focus, select:focus, textarea:focus {
-      outline: 2px solid rgba(124, 77, 255, 0.6);
+      outline: 2px solid rgba(212, 162, 76, 0.55);
       outline-offset: 1px;
     }
 
@@ -719,25 +739,25 @@
       border-radius: 16px;
       padding: 14px 16px;
       font-size: 14px;
-      background: rgba(255, 255, 255, 0.06);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      color: #dde5ff;
+      background: rgba(31, 41, 55, 0.04);
+      border: 1px solid rgba(31, 41, 55, 0.12);
+      color: var(--ink);
     }
 
     .status.success {
-      background: rgba(55, 199, 154, 0.22);
-      border-color: rgba(55, 199, 154, 0.6);
-      color: #ecfff7;
+      background: rgba(122, 157, 146, 0.18);
+      border-color: rgba(122, 157, 146, 0.5);
+      color: #2f4f4f;
     }
 
     .status.error {
-      background: rgba(255, 86, 132, 0.22);
-      border-color: rgba(255, 86, 132, 0.55);
-      color: #ffe9f0;
+      background: rgba(217, 83, 79, 0.12);
+      border-color: rgba(217, 83, 79, 0.4);
+      color: #7a1d1a;
     }
 
     .status a {
-      color: #fff;
+      color: var(--accent);
       word-break: break-all;
     }
 
@@ -778,11 +798,11 @@
       background: var(--card);
       border-radius: 20px;
       overflow: hidden;
-      border: 1px solid rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(31, 41, 55, 0.1);
       display: flex;
       flex-direction: column;
       min-height: 100%;
-      box-shadow: 0 24px 50px rgba(2, 8, 25, 0.45);
+      box-shadow: 0 20px 36px rgba(31, 41, 55, 0.14);
     }
 
     .manage-card {
@@ -796,8 +816,8 @@
       gap: 8px;
       padding: 6px;
       border-radius: 18px;
-      background: rgba(10, 17, 36, 0.6);
-      border: 1px solid rgba(124, 77, 255, 0.28);
+      background: rgba(212, 162, 76, 0.08);
+      border: 1px solid rgba(212, 162, 76, 0.24);
     }
 
     .manage-tab {
@@ -809,20 +829,20 @@
       text-transform: uppercase;
       letter-spacing: 0.6px;
       background: transparent;
-      color: rgba(223, 228, 255, 0.72);
+      color: var(--muted);
       cursor: pointer;
       transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
     }
 
     .manage-tab:focus-visible {
-      outline: 2px solid rgba(124, 77, 255, 0.6);
+      outline: 2px solid rgba(212, 162, 76, 0.55);
       outline-offset: 2px;
     }
 
     .manage-tab.is-active {
-      background: linear-gradient(135deg, rgba(124, 77, 255, 0.75), rgba(55, 199, 154, 0.6));
+      background: linear-gradient(135deg, rgba(212, 162, 76, 0.85), rgba(122, 157, 146, 0.65));
       color: #fff;
-      box-shadow: 0 14px 28px rgba(76, 71, 143, 0.35);
+      box-shadow: 0 12px 24px rgba(212, 162, 76, 0.26);
     }
 
     .tab-panels {
@@ -848,7 +868,7 @@
       position: relative;
       width: 100%;
       padding-top: 60%;
-      background: linear-gradient(135deg, rgba(124, 77, 255, 0.45), rgba(55, 199, 154, 0.3));
+      background: linear-gradient(135deg, rgba(244, 220, 184, 0.65), rgba(218, 229, 223, 0.6));
     }
 
     .community-media img {
@@ -868,7 +888,7 @@
       font-size: 36px;
       font-weight: 700;
       letter-spacing: 1px;
-      color: rgba(255, 255, 255, 0.85);
+      color: rgba(31, 41, 55, 0.35);
       text-transform: uppercase;
     }
 
@@ -892,7 +912,7 @@
     .community-meta span {
       padding: 4px 8px;
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.08);
+      background: rgba(31, 41, 55, 0.06);
     }
 
     .community-body h3 {
@@ -915,7 +935,7 @@
     .progress-bar {
       height: 8px;
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.08);
+      background: rgba(31, 41, 55, 0.1);
       overflow: hidden;
     }
 
@@ -965,7 +985,8 @@
       text-align: center;
       color: var(--muted);
       font-size: 14px;
-      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      border-top: 1px solid rgba(31, 41, 55, 0.1);
+      background: rgba(255, 255, 255, 0.9);
     }
 
     @media (max-width: 900px) {
@@ -1134,8 +1155,8 @@
       margin-top: 12px;
       padding: 16px;
       border-radius: 16px;
-      background: rgba(255, 255, 255, 0.06);
-      border: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid rgba(31, 41, 55, 0.12);
       display: grid;
       gap: 8px;
     }
@@ -1144,7 +1165,7 @@
       margin: 0;
       font-family: "JetBrains Mono", Consolas, monospace;
       font-size: 12px;
-      color: #d2dbff;
+      color: var(--muted);
       white-space: pre-wrap;
       word-break: break-word;
     }
@@ -1229,6 +1250,10 @@
       .hero {
         grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
         gap: 36px;
+      }
+
+      .region-media {
+        height: 260px;
       }
     }
 
@@ -1450,10 +1475,7 @@
               </label>
             </div>
             <div class="form-actions">
-              <button class="btn liquid" type="submit">
-                <span>Save organization</span>
-                <div class="liquid"></div>
-              </button>
+              <button class="btn ghost" type="submit">Save organization</button>
             </div>
           </form>
           <div class="status" id="setup-org-status" hidden></div>


### PR DESCRIPTION
## Summary
- restyled the multifaith giving platform page with a light, faith-inspired palette and softer UI elements
- tightened the regional gallery slider layout so each slide stays within the viewport and refined supporting cards
- simplified the “Save organization” action to match the ghost button treatment used by “Explore regions”

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68e2c029302c832dbca4277ab1214dd4