### PR TITLE
Ensure regional currency thumbnails are fully visible

### DIFF
--- a/public/multifaith-giving-platform.html
+++ b/public/multifaith-giving-platform.html
@@ -519,7 +519,9 @@
       width: 72px;
       height: 48px;
       border-radius: 10px;
-      object-fit: cover;
+      object-fit: contain;
+      object-position: center;
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(243, 246, 248, 0.9));
       box-shadow: inset 0 0 0 1px rgba(31, 41, 55, 0.12);
     }
 


### PR DESCRIPTION
## Summary
- update the regional currency image styling on the multi-faith giving platform page so the full bill artwork remains visible
- add a subtle background treatment to the thumbnail to preserve contrast when using object-fit contain

## Testing
- not run (static change)


------
https://chatgpt.com/codex/tasks/task_e_68e2e4cc3960832d8fb31409330ab1c3