### PR TITLE
Add quick Stripe donation tabs and slider experience

### DIFF
--- a/public/multifaith-giving-platform.html
+++ b/public/multifaith-giving-platform.html
@@ -900,6 +900,294 @@
       gap: 24px;
     }
 
+    .quick-stripe-section {
+      display: grid;
+      gap: 28px;
+    }
+
+    .quick-stripe-card {
+      background: linear-gradient(145deg, rgba(212, 162, 76, 0.22), rgba(122, 157, 146, 0.18));
+      border-radius: 28px;
+      border: 1px solid rgba(212, 162, 76, 0.28);
+      padding: 32px;
+      display: grid;
+      gap: 26px;
+      box-shadow: 0 28px 46px rgba(31, 41, 55, 0.18);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .quick-stripe-card::before {
+      content: '';
+      position: absolute;
+      inset: -40% 35% auto -20%;
+      height: 260px;
+      background: radial-gradient(circle at top, rgba(255, 255, 255, 0.65), transparent 70%);
+      opacity: 0.75;
+      pointer-events: none;
+    }
+
+    .quick-stripe-card > * {
+      position: relative;
+      z-index: 1;
+    }
+
+    .quick-tabs {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      padding: 8px;
+      border-radius: 18px;
+      background: rgba(255, 255, 255, 0.4);
+      border: 1px solid rgba(212, 162, 76, 0.32);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+    }
+
+    .quick-tabs .manage-tab {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      padding: 14px 18px;
+      flex: 1 1 160px;
+      background: transparent;
+      backdrop-filter: blur(2px);
+      -webkit-backdrop-filter: blur(2px);
+      color: var(--muted);
+      border: 1px solid transparent;
+    }
+
+    .quick-tabs .manage-tab .quick-tab-icon {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(255, 255, 255, 0.6);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+    }
+
+    .quick-tabs .manage-tab svg {
+      width: 20px;
+      height: 20px;
+    }
+
+    .quick-tabs .manage-tab.is-active {
+      color: #fff;
+      border-color: rgba(255, 255, 255, 0.45);
+      box-shadow: 0 18px 32px rgba(212, 162, 76, 0.35);
+    }
+
+    .quick-tabs .manage-tab.is-active .quick-tab-icon {
+      background: rgba(255, 255, 255, 0.9);
+    }
+
+    .quick-panel {
+      display: grid;
+      gap: 24px;
+    }
+
+    .quick-faith-intro {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px 24px;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .quick-faith-heading {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: 0.4px;
+    }
+
+    .quick-faith-heading span {
+      display: block;
+      font-size: 15px;
+      font-weight: 500;
+      color: rgba(31, 41, 55, 0.75);
+    }
+
+    .quick-faith-icon {
+      width: 64px;
+      height: 64px;
+      border-radius: 50%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(255, 255, 255, 0.65);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+    }
+
+    .quick-faith-icon svg {
+      width: 38px;
+      height: 38px;
+    }
+
+    .quick-amounts {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .quick-amount {
+      border: 1px solid rgba(31, 41, 55, 0.08);
+      border-radius: 18px;
+      padding: 18px;
+      background: rgba(255, 255, 255, 0.75);
+      font-weight: 700;
+      display: grid;
+      gap: 6px;
+      justify-items: start;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    }
+
+    .quick-amount span {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+    }
+
+    .quick-amount.is-selected {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 28px rgba(31, 41, 55, 0.18);
+      border-color: rgba(212, 162, 76, 0.55);
+    }
+
+    .quick-slider-wrapper {
+      display: grid;
+      gap: 12px;
+    }
+
+    .quick-slider-track {
+      position: relative;
+      width: 100%;
+      height: 12px;
+      background: rgba(255, 255, 255, 0.55);
+      border-radius: 999px;
+      border: 1px solid rgba(31, 41, 55, 0.08);
+      overflow: hidden;
+    }
+
+    .quick-slider-progress {
+      position: absolute;
+      inset: 0 auto 0 0;
+      width: 0%;
+      background: linear-gradient(117deg, rgba(212, 162, 76, 0.95) 0%, rgba(122, 157, 146, 0.95) 100%);
+      border-radius: inherit;
+      transition: width 0.2s ease;
+    }
+
+    .quick-slider-thumb {
+      position: absolute;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      width: 72px;
+      height: 48px;
+      border-radius: 999px;
+      cursor: pointer;
+      background: rgba(255, 255, 255, 0.92);
+      box-shadow: 0 1px 8px rgba(0, 30, 63, 0.12), 0 0 2px rgba(0, 9, 20, 0.1);
+      overflow: hidden;
+      transition: transform 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
+    }
+
+    .quick-slider-thumb::before,
+    .quick-slider-thumb::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+    }
+
+    .quick-slider-thumb::before {
+      background: rgba(255, 255, 255, 0.2);
+    }
+
+    .quick-slider-thumb::after {
+      background: linear-gradient(135deg, rgba(212, 162, 76, 0.35), rgba(122, 157, 146, 0.28));
+      mix-blend-mode: screen;
+    }
+
+    .quick-slider-thumb-filter,
+    .quick-slider-thumb-overlay,
+    .quick-slider-thumb-specular {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+    }
+
+    .quick-slider-thumb-filter {
+      backdrop-filter: blur(0.6px);
+      -webkit-backdrop-filter: blur(0.6px);
+      filter: url(#quick-liquid-lens);
+    }
+
+    .quick-slider-thumb-overlay {
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    .quick-slider-thumb-specular {
+      border-radius: inherit;
+      box-shadow:
+        inset 1px 1px 0 rgba(212, 162, 76, 0.22),
+        inset 1px 3px 0 rgba(28, 63, 90, 0.08),
+        inset 0 0 22px rgba(255, 255, 255, 0.6),
+        inset -1px -1px 0 rgba(212, 162, 76, 0.18);
+    }
+
+    .quick-slider-thumb.active {
+      transform: translate(-50%, -50%) scale(1.04);
+      box-shadow: 0 0 0 4px rgba(212, 162, 76, 0.12), 0 18px 38px rgba(31, 41, 55, 0.28);
+      background: rgba(255, 255, 255, 0.75);
+    }
+
+    .quick-slider-thumb.active .quick-slider-thumb-filter,
+    .quick-slider-thumb.active .quick-slider-thumb-overlay,
+    .quick-slider-thumb.active .quick-slider-thumb-specular {
+      opacity: 1;
+    }
+
+    .quick-slider-value {
+      font-size: 14px;
+      font-weight: 600;
+      color: rgba(31, 41, 55, 0.8);
+    }
+
+    .quick-summary {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px 24px;
+      align-items: center;
+      justify-content: space-between;
+      padding: 18px 20px;
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.6);
+      border: 1px solid rgba(31, 41, 55, 0.08);
+    }
+
+    .quick-summary strong {
+      font-size: 18px;
+    }
+
+    .quick-summary span {
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .quick-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      justify-content: flex-end;
+    }
+
     .manage-tabs {
       display: flex;
       flex-wrap: wrap;
@@ -1108,6 +1396,46 @@
       .hero p {
         font-size: 16px;
         margin: 12px 0 20px;
+      }
+
+      .quick-stripe-card {
+        padding: 24px;
+        border-radius: 22px;
+      }
+
+      .quick-tabs {
+        gap: 6px;
+      }
+
+      .quick-tabs .manage-tab {
+        flex: 1 1 140px;
+        font-size: 13px;
+        padding: 12px 14px;
+      }
+
+      .quick-faith-heading {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+
+      .quick-faith-icon {
+        width: 52px;
+        height: 52px;
+      }
+
+      .quick-faith-icon svg {
+        width: 30px;
+        height: 30px;
+      }
+
+      .quick-amounts {
+        grid-template-columns: 1fr;
+      }
+
+      .quick-summary {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 18px;
       }
 
       .hero-media {
@@ -1422,6 +1750,140 @@
     </div>
   </section>
 
+  <section id="quick-stripe" class="quick-stripe-section">
+    <h2>Quick Stripe payment lanes</h2>
+    <p class="lead">Drop into a tradition, lock in a preset gift, and spin up a secure Stripe checkout without any typing. Pick a lane, tune the amplifier, and tap the button to move funds right now.</p>
+    <div class="quick-stripe-card">
+      <div class="quick-tabs" role="tablist" aria-label="Faith traditions for instant payments">
+        <button class="manage-tab is-active" type="button" role="tab" aria-selected="true" aria-controls="quick-panel" id="quick-tab-christian" data-faith="christian">
+          <span class="quick-tab-icon" aria-hidden="true">
+            <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" focusable="false">
+              <g fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M32 8v48"/>
+                <path d="M18 20h28"/>
+              </g>
+            </svg>
+          </span>
+          Christian
+        </button>
+        <button class="manage-tab" type="button" role="tab" aria-selected="false" aria-controls="quick-panel" id="quick-tab-islam" data-faith="islam">
+          <span class="quick-tab-icon" aria-hidden="true">
+            <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" focusable="false">
+              <path d="M40 8a20 20 0 1 0 0 48 22 22 0 1 1 0-48z" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="m46 32 10 4-10 4 6 9-10-4-2 11-2-11-10 4 6-9-10-4 10-4-6-9 10 4 2-11 2 11 10-4z" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          Islamic
+        </button>
+        <button class="manage-tab" type="button" role="tab" aria-selected="false" aria-controls="quick-panel" id="quick-tab-jewish" data-faith="jewish">
+          <span class="quick-tab-icon" aria-hidden="true">
+            <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" focusable="false">
+              <path d="m32 6 10 18h-20l10-18zm0 52-10-18h20l-10 18zm-22-18 10-18 10 18H10zm44 0H34l10-18 10 18z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          Jewish
+        </button>
+        <button class="manage-tab" type="button" role="tab" aria-selected="false" aria-controls="quick-panel" id="quick-tab-hindu" data-faith="hindu">
+          <span class="quick-tab-icon" aria-hidden="true">
+            <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" focusable="false">
+              <path d="M20 24c0-6.627 5.373-12 12-12s12 5.373 12 12-5.373 12-12 12" fill="none" stroke="currentColor" stroke-width="4"/>
+              <path d="M32 36c-6 0-11 3.582-11 8s5 8 11 8 11-3.582 11-8" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round"/>
+              <path d="M30 18c0-3.314 2.239-6 5-6 2.209 0 4 1.791 4 4 0 1.657-1.343 3-3 3" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+              <path d="M14 24h12M38 24h12" stroke="currentColor" stroke-width="4" stroke-linecap="round"/>
+            </svg>
+          </span>
+          Hindu
+        </button>
+        <button class="manage-tab" type="button" role="tab" aria-selected="false" aria-controls="quick-panel" id="quick-tab-buddhist" data-faith="buddhist">
+          <span class="quick-tab-icon" aria-hidden="true">
+            <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" focusable="false">
+              <circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-width="4"/>
+              <g fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round">
+                <path d="M32 8v10"/>
+                <path d="M32 46v10"/>
+                <path d="M8 32h10"/>
+                <path d="M46 32h10"/>
+                <path d="m14 14 7 7"/>
+                <path d="m43 43 7 7"/>
+                <path d="m14 50 7-7"/>
+                <path d="m43 21 7-7"/>
+              </g>
+            </svg>
+          </span>
+          Buddhist
+        </button>
+      </div>
+      <div class="quick-panel" id="quick-panel" role="tabpanel" aria-labelledby="quick-tab-christian">
+        <div class="quick-faith-intro">
+          <div class="quick-faith-heading">
+            <div class="quick-faith-icon" id="quick-faith-icon" aria-hidden="true">
+              <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                <g fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M32 8v48"/>
+                  <path d="M18 20h28"/>
+                </g>
+              </svg>
+            </div>
+            <div>
+              <strong id="quick-faith-title">Christian ministries</strong>
+              <span id="quick-faith-subtitle">Direct support for parish life, community meals, and global missions.</span>
+            </div>
+          </div>
+          <div class="quick-slider-value">Multiplier: <span id="quick-multiplier-label">1.0×</span></div>
+        </div>
+        <div class="quick-amounts" id="quick-amounts">
+          <button class="quick-amount is-selected" type="button" data-index="0">
+            <strong id="quick-amount-0">$75</strong>
+            <span id="quick-amount-desc-0">Launch midweek meals</span>
+          </button>
+          <button class="quick-amount" type="button" data-index="1">
+            <strong id="quick-amount-1">$150</strong>
+            <span id="quick-amount-desc-1">Fuel regional outreach</span>
+          </button>
+          <button class="quick-amount" type="button" data-index="2">
+            <strong id="quick-amount-2">$300</strong>
+            <span id="quick-amount-desc-2">Underwrite community care</span>
+          </button>
+        </div>
+        <div class="quick-slider-wrapper">
+          <div class="quick-slider-track" id="quick-slider" role="slider" aria-valuemin="75" aria-valuemax="250" aria-valuenow="100" aria-label="Donation multiplier" tabindex="0">
+            <div class="quick-slider-progress" id="quick-slider-progress"></div>
+            <div class="quick-slider-thumb" id="quick-slider-thumb">
+              <div class="quick-slider-thumb-filter"></div>
+              <div class="quick-slider-thumb-overlay"></div>
+              <div class="quick-slider-thumb-specular"></div>
+            </div>
+          </div>
+        </div>
+        <div class="quick-summary">
+          <div>
+            <strong id="quick-total">$225 ready for checkout</strong>
+            <span id="quick-total-detail">Split across worship, meals, and relief in this lane.</span>
+          </div>
+          <div class="quick-actions">
+            <button class="btn liquid" type="button" id="quick-generate">
+              <span>Generate secure checkout</span>
+              <div class="liquid"></div>
+            </button>
+            <button class="btn liquid" type="button" id="quick-share">
+              <span>Create a donation link</span>
+              <div class="liquid"></div>
+            </button>
+          </div>
+        </div>
+      </div>
+      <svg width="0" height="0" aria-hidden="true">
+        <filter id="quick-liquid-lens" x="-50%" y="-50%" width="200%" height="200%">
+          <feImage x="0" y="0" result="normalMap" xlink:href="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='300' height='300'&gt;&lt;radialGradient id='invmap' cx='50%' cy='50%' r='75%'&gt;&lt;stop offset='0%' stop-color='rgb(128,128,255)'/&gt;&lt;stop offset='90%' stop-color='rgb(255,255,255)'/&gt;&lt;/radialGradient&gt;&lt;rect width='100%' height='100%' fill='url(#invmap)'/&gt;&lt;/svg>"/>
+          <feDisplacementMap in="SourceGraphic" in2="normalMap" scale="-220" xChannelSelector="R" yChannelSelector="G" result="displaced"/>
+          <feMerge>
+            <feMergeNode in="displaced"/>
+          </feMerge>
+        </filter>
+      </svg>
+    </div>
+  </section>
+
   <section id="regions">
     <h2>Regional gallery</h2>
     <p class="lead">Preview the localized experience for every launch territory. Each slide shows live copy, receipt preferences, and sector highlights donors will see.</p>
@@ -1616,6 +2078,413 @@
 </footer>
 
 <script>
+  const QUICK_FAITHS = [
+    {
+      key: 'christian',
+      title: 'Christian ministries',
+      subtitle: 'Direct support for parish life, community meals, and global missions.',
+      detail: 'Split across worship, meals, and relief in this lane.',
+      currency: 'USD',
+      locale: 'en-US',
+      gradient: 'linear-gradient(135deg, rgba(212, 162, 76, 0.95), rgba(122, 157, 146, 0.95))',
+      cardGradient: 'linear-gradient(145deg, rgba(212, 162, 76, 0.22), rgba(122, 157, 146, 0.18))',
+      borderColor: 'rgba(212, 162, 76, 0.45)',
+      summaryBorder: 'rgba(212, 162, 76, 0.4)',
+      shadow: '0 18px 32px rgba(212, 162, 76, 0.35)',
+      summaryShadow: '0 14px 28px rgba(212, 162, 76, 0.25)',
+      amounts: [
+        { base: 75, label: 'Launch midweek meals' },
+        { base: 150, label: 'Fuel regional outreach' },
+        { base: 300, label: 'Underwrite community care' }
+      ],
+      icon: '<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"><path d="M32 8v48"/><path d="M18 20h28"/></g></svg>',
+      ctaGenerate: 'Generate secure checkout',
+      ctaShare: 'Create a donation link'
+    },
+    {
+      key: 'islam',
+      title: 'Masjid & zakat partners',
+      subtitle: 'Elevate Ramadan hampers, zakat distribution, and daily prayers.',
+      detail: 'Balances zakat, sadaqah, and masjid operations in one sweep.',
+      currency: 'AED',
+      locale: 'en-AE',
+      gradient: 'linear-gradient(135deg, rgba(91, 153, 136, 0.95), rgba(64, 126, 110, 0.95))',
+      cardGradient: 'linear-gradient(145deg, rgba(91, 153, 136, 0.24), rgba(64, 126, 110, 0.2))',
+      borderColor: 'rgba(91, 153, 136, 0.5)',
+      summaryBorder: 'rgba(91, 153, 136, 0.45)',
+      shadow: '0 18px 32px rgba(64, 126, 110, 0.32)',
+      summaryShadow: '0 14px 28px rgba(64, 126, 110, 0.26)',
+      amounts: [
+        { base: 200, label: 'Stock Eid food parcels' },
+        { base: 350, label: 'Sponsor zakat disbursement' },
+        { base: 600, label: 'Fund masjid restoration' }
+      ],
+      icon: '<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><path d="M40 8a20 20 0 1 0 0 48 22 22 0 1 1 0-48z" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/><path d="m46 32 10 4-10 4 6 9-10-4-2 11-2-11-10 4 6-9-10-4 10-4-6-9 10 4 2-11 2 11 10-4z" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+      ctaGenerate: 'Launch masjid checkout',
+      ctaShare: 'Share zakat link'
+    },
+    {
+      key: 'jewish',
+      title: 'Synagogues & federations',
+      subtitle: 'Back Hebrew schools, security training, and cultural preservation.',
+      detail: 'Allocates toward education, safety, and cultural life at once.',
+      currency: 'ILS',
+      locale: 'he-IL',
+      gradient: 'linear-gradient(135deg, rgba(73, 131, 196, 0.95), rgba(36, 96, 172, 0.95))',
+      cardGradient: 'linear-gradient(145deg, rgba(73, 131, 196, 0.24), rgba(36, 96, 172, 0.22))',
+      borderColor: 'rgba(73, 131, 196, 0.5)',
+      summaryBorder: 'rgba(73, 131, 196, 0.45)',
+      shadow: '0 18px 32px rgba(36, 96, 172, 0.32)',
+      summaryShadow: '0 14px 28px rgba(36, 96, 172, 0.26)',
+      amounts: [
+        { base: 180, label: 'Sponsor Hebrew school supplies' },
+        { base: 360, label: 'Underwrite security detail' },
+        { base: 720, label: 'Preserve cultural archives' }
+      ],
+      icon: '<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><path d="m32 6 10 18h-20l10-18zm0 52-10-18h20l-10 18zm-22-18 10-18 10 18H10zm44 0H34l10-18 10 18z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/></svg>',
+      ctaGenerate: 'Send synagogue checkout',
+      ctaShare: 'Share federation link'
+    },
+    {
+      key: 'hindu',
+      title: 'Temple seva circles',
+      subtitle: 'Keep aarti, prasadam kitchens, and youth satsangs thriving.',
+      detail: 'Energizes seva teams, annadanam, and temple upkeep together.',
+      currency: 'INR',
+      locale: 'en-IN',
+      gradient: 'linear-gradient(135deg, rgba(226, 153, 73, 0.95), rgba(199, 98, 35, 0.95))',
+      cardGradient: 'linear-gradient(145deg, rgba(226, 153, 73, 0.26), rgba(199, 98, 35, 0.22))',
+      borderColor: 'rgba(226, 153, 73, 0.55)',
+      summaryBorder: 'rgba(226, 153, 73, 0.48)',
+      shadow: '0 18px 32px rgba(199, 98, 35, 0.32)',
+      summaryShadow: '0 14px 28px rgba(199, 98, 35, 0.28)',
+      amounts: [
+        { base: 3500, label: 'Prepare daily prasadam' },
+        { base: 6500, label: 'Sponsor festival seva teams' },
+        { base: 12000, label: 'Restore garbhagriha artistry' }
+      ],
+      icon: '<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><path d="M20 24c0-6.627 5.373-12 12-12s12 5.373 12 12-5.373 12-12 12" fill="none" stroke="currentColor" stroke-width="4"/><path d="M32 36c-6 0-11 3.582-11 8s5 8 11 8 11-3.582 11-8" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round"/><path d="M30 18c0-3.314 2.239-6 5-6 2.209 0 4 1.791 4 4 0 1.657-1.343 3-3 3" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/><path d="M14 24h12M38 24h12" stroke="currentColor" stroke-width="4" stroke-linecap="round"/></svg>',
+      ctaGenerate: 'Launch temple checkout',
+      ctaShare: 'Share seva link'
+    },
+    {
+      key: 'buddhist',
+      title: 'Sangha retreats & relief',
+      subtitle: 'Resource meditation halls, dana kitchens, and elder care.',
+      detail: 'Streams dana across retreats, monastics, and community care.',
+      currency: 'SGD',
+      locale: 'en-SG',
+      gradient: 'linear-gradient(135deg, rgba(122, 157, 146, 0.95), rgba(88, 136, 128, 0.95))',
+      cardGradient: 'linear-gradient(145deg, rgba(122, 157, 146, 0.24), rgba(88, 136, 128, 0.22))',
+      borderColor: 'rgba(122, 157, 146, 0.5)',
+      summaryBorder: 'rgba(122, 157, 146, 0.45)',
+      shadow: '0 18px 32px rgba(88, 136, 128, 0.32)',
+      summaryShadow: '0 14px 28px rgba(88, 136, 128, 0.26)',
+      amounts: [
+        { base: 220, label: 'Sponsor dana meal service' },
+        { base: 420, label: 'Support retreat scholarships' },
+        { base: 880, label: 'Fund monastic healthcare' }
+      ],
+      icon: '<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-width="4"/><g fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round"><path d="M32 8v10"/><path d="M32 46v10"/><path d="M8 32h10"/><path d="M46 32h10"/><path d="m14 14 7 7"/><path d="m43 43 7 7"/><path d="m14 50 7-7"/><path d="m43 21 7-7"/></g></svg>',
+      ctaGenerate: 'Send sangha checkout',
+      ctaShare: 'Share dana link'
+    }
+  ];
+
+  const QUICK_FAITH_MAP = new Map(QUICK_FAITHS.map((faith) => [faith.key, faith]));
+
+  const quickStripeCard = document.querySelector('.quick-stripe-card');
+
+  if (quickStripeCard) {
+    const quickTabs = Array.from(quickStripeCard.querySelectorAll('.manage-tab'));
+    const quickAmounts = Array.from(quickStripeCard.querySelectorAll('.quick-amount'));
+    const quickFaithIcon = document.getElementById('quick-faith-icon');
+    const quickFaithTitle = document.getElementById('quick-faith-title');
+    const quickFaithSubtitle = document.getElementById('quick-faith-subtitle');
+    const quickMultiplierLabel = document.getElementById('quick-multiplier-label');
+    const quickSliderTrack = document.getElementById('quick-slider');
+    const quickSliderProgress = document.getElementById('quick-slider-progress');
+    const quickSliderThumb = document.getElementById('quick-slider-thumb');
+    const quickTotal = document.getElementById('quick-total');
+    const quickTotalDetail = document.getElementById('quick-total-detail');
+    const quickSummary = quickStripeCard.querySelector('.quick-summary');
+    const quickGenerateBtn = document.getElementById('quick-generate');
+    const quickShareBtn = document.getElementById('quick-share');
+    const quickGenerateLabel = quickGenerateBtn ? quickGenerateBtn.querySelector('span') : null;
+    const quickShareLabel = quickShareBtn ? quickShareBtn.querySelector('span') : null;
+
+    if (!quickSliderTrack || !quickSliderProgress || !quickSliderThumb || !quickMultiplierLabel || !quickTotal) {
+      return;
+    }
+
+    const QUICK_SLIDER_MIN = 0.75;
+    const QUICK_SLIDER_MAX = 2.5;
+    const QUICK_SLIDER_STEP = 0.01;
+    const QUICK_PERCENT_STEP = 3.5;
+    const QUICK_PERCENT_FINE = 1.5;
+
+    const amountFormatters = new Map();
+
+    const quickState = {
+      faith: QUICK_FAITHS[0]?.key ?? null,
+      multiplier: 1,
+      selectedIndex: 0
+    };
+
+    let quickSliderRect = quickSliderTrack.getBoundingClientRect();
+    let quickSliderPercent = 0;
+    let quickSliderDragging = false;
+
+    quickSliderTrack.setAttribute('aria-valuemin', String(Math.round(QUICK_SLIDER_MIN * 100)));
+    quickSliderTrack.setAttribute('aria-valuemax', String(Math.round(QUICK_SLIDER_MAX * 100)));
+
+    function formatAmount(value, currency, locale) {
+      const key = `${locale}-${currency}`;
+      if (!amountFormatters.has(key)) {
+        amountFormatters.set(
+          key,
+          new Intl.NumberFormat(locale, {
+            style: 'currency',
+            currency,
+            maximumFractionDigits: 0,
+            minimumFractionDigits: 0
+          })
+        );
+      }
+      return amountFormatters.get(key).format(Math.max(0, Math.round(value)));
+    }
+
+    function formatMultiplier(value) {
+      const fixed = value.toFixed(2);
+      return `${fixed.replace(/0+$/, '').replace(/\.$/, '')}×`;
+    }
+
+    function percentToMultiplier(percent) {
+      return QUICK_SLIDER_MIN + (Math.max(0, Math.min(100, percent)) / 100) * (QUICK_SLIDER_MAX - QUICK_SLIDER_MIN);
+    }
+
+    function multiplierToPercent(multiplier) {
+      const clamped = Math.max(QUICK_SLIDER_MIN, Math.min(QUICK_SLIDER_MAX, multiplier));
+      return ((clamped - QUICK_SLIDER_MIN) / (QUICK_SLIDER_MAX - QUICK_SLIDER_MIN)) * 100;
+    }
+
+    function applySliderPosition() {
+      quickSliderProgress.style.width = `${quickSliderPercent}%`;
+      quickSliderThumb.style.left = `${quickSliderPercent}%`;
+      const ariaValue = Math.round(quickState.multiplier * 100);
+      quickSliderTrack.setAttribute('aria-valuenow', String(ariaValue));
+      quickSliderTrack.setAttribute('aria-valuetext', `${quickState.multiplier.toFixed(2)} times base gift`);
+      quickMultiplierLabel.textContent = formatMultiplier(quickState.multiplier);
+    }
+
+    function updateQuickAmounts() {
+      const config = QUICK_FAITH_MAP.get(quickState.faith);
+      if (!config) return;
+
+      quickAmounts.forEach((button, index) => {
+        const amountConfig = config.amounts[index] ?? config.amounts[config.amounts.length - 1];
+        const scaled = Math.round(amountConfig.base * quickState.multiplier / 5) * 5;
+        button.dataset.index = String(index);
+        button.dataset.amountValue = String(Math.max(0, scaled));
+        const valueLabel = button.querySelector('strong');
+        const descLabel = button.querySelector('span');
+        if (valueLabel) {
+          valueLabel.textContent = formatAmount(scaled, config.currency, config.locale);
+        }
+        if (descLabel) {
+          descLabel.textContent = amountConfig.label;
+        }
+        button.classList.toggle('is-selected', index === quickState.selectedIndex);
+      });
+
+      const activeButton = quickAmounts[quickState.selectedIndex];
+      const activeAmount = activeButton ? Number(activeButton.dataset.amountValue ?? 0) : 0;
+      quickTotal.textContent = `${formatAmount(activeAmount, config.currency, config.locale)} ready for checkout`;
+    }
+
+    function updateQuickVisuals() {
+      const config = QUICK_FAITH_MAP.get(quickState.faith);
+      if (!config) return;
+
+      if (quickFaithIcon) {
+        quickFaithIcon.innerHTML = config.icon;
+      }
+      if (quickFaithTitle) {
+        quickFaithTitle.textContent = config.title;
+      }
+      if (quickFaithSubtitle) {
+        quickFaithSubtitle.textContent = config.subtitle;
+      }
+      if (quickTotalDetail) {
+        quickTotalDetail.textContent = config.detail;
+      }
+      if (quickGenerateLabel) {
+        quickGenerateLabel.textContent = config.ctaGenerate;
+      }
+      if (quickShareLabel) {
+        quickShareLabel.textContent = config.ctaShare;
+      }
+
+      quickStripeCard.style.backgroundImage = config.cardGradient;
+      quickStripeCard.style.borderColor = config.borderColor;
+      quickSliderProgress.style.backgroundImage = config.gradient;
+      if (quickSummary) {
+        quickSummary.style.borderColor = config.summaryBorder;
+        quickSummary.style.boxShadow = config.summaryShadow;
+      }
+
+      quickTabs.forEach((tab) => {
+        const isActive = tab.dataset.faith === quickState.faith;
+        tab.classList.toggle('is-active', isActive);
+        tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        tab.style.background = isActive ? config.gradient : 'transparent';
+        tab.style.color = isActive ? '#fff' : '';
+        tab.style.boxShadow = isActive ? config.shadow : '';
+      });
+
+      updateQuickAmounts();
+    }
+
+    function setQuickFaith(key) {
+      if (!QUICK_FAITH_MAP.has(key)) return;
+      quickState.faith = key;
+      quickState.selectedIndex = 0;
+      updateQuickVisuals();
+    }
+
+    function setQuickPercent(percent) {
+      const clamped = Math.max(0, Math.min(100, percent));
+      quickSliderPercent = clamped;
+      const rawMultiplier = percentToMultiplier(clamped);
+      const roundedMultiplier = Math.round(rawMultiplier / QUICK_SLIDER_STEP) * QUICK_SLIDER_STEP;
+      quickState.multiplier = Math.max(QUICK_SLIDER_MIN, Math.min(QUICK_SLIDER_MAX, Number(roundedMultiplier.toFixed(2))));
+      applySliderPosition();
+      updateQuickAmounts();
+    }
+
+    function updateQuickFromClient(clientX) {
+      if (!quickSliderRect || quickSliderRect.width === 0) return;
+      const offset = clientX - quickSliderRect.left;
+      const percent = (offset / quickSliderRect.width) * 100;
+      setQuickPercent(percent);
+    }
+
+    function startSliderDrag(clientX) {
+      quickSliderDragging = true;
+      quickSliderRect = quickSliderTrack.getBoundingClientRect();
+      quickSliderThumb.classList.add('active');
+      updateQuickFromClient(clientX);
+    }
+
+    function stopSliderDrag() {
+      if (!quickSliderDragging) return;
+      quickSliderDragging = false;
+      quickSliderThumb.classList.remove('active');
+    }
+
+    quickTabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        setQuickFaith(tab.dataset.faith);
+      });
+    });
+
+    quickAmounts.forEach((button) => {
+      button.addEventListener('click', () => {
+        const index = Number(button.dataset.index ?? 0);
+        quickState.selectedIndex = index;
+        updateQuickAmounts();
+      });
+    });
+
+    quickSliderThumb.addEventListener('mousedown', (event) => {
+      event.preventDefault();
+      startSliderDrag(event.clientX);
+    });
+
+    quickSliderTrack.addEventListener('mousedown', (event) => {
+      event.preventDefault();
+      startSliderDrag(event.clientX);
+    });
+
+    document.addEventListener('mousemove', (event) => {
+      if (!quickSliderDragging) return;
+      updateQuickFromClient(event.clientX);
+    });
+
+    document.addEventListener('mouseup', stopSliderDrag);
+
+    quickSliderThumb.addEventListener(
+      'touchstart',
+      (event) => {
+        event.preventDefault();
+        const touch = event.touches[0];
+        if (touch) {
+          startSliderDrag(touch.clientX);
+        }
+      },
+      { passive: false }
+    );
+
+    quickSliderTrack.addEventListener(
+      'touchstart',
+      (event) => {
+        const touch = event.touches[0];
+        if (touch) {
+          startSliderDrag(touch.clientX);
+        }
+      },
+      { passive: true }
+    );
+
+    document.addEventListener(
+      'touchmove',
+      (event) => {
+        if (!quickSliderDragging) return;
+        const touch = event.touches[0];
+        if (touch) {
+          event.preventDefault();
+          updateQuickFromClient(touch.clientX);
+        }
+      },
+      { passive: false }
+    );
+
+    document.addEventListener('touchend', stopSliderDrag);
+    document.addEventListener('touchcancel', stopSliderDrag);
+
+    quickSliderTrack.addEventListener('keydown', (event) => {
+      let handled = false;
+      if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+        const step = event.shiftKey ? QUICK_PERCENT_FINE : QUICK_PERCENT_STEP;
+        setQuickPercent(quickSliderPercent + step);
+        handled = true;
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+        const step = event.shiftKey ? QUICK_PERCENT_FINE : QUICK_PERCENT_STEP;
+        setQuickPercent(quickSliderPercent - step);
+        handled = true;
+      } else if (event.key === 'Home') {
+        setQuickPercent(0);
+        handled = true;
+      } else if (event.key === 'End') {
+        setQuickPercent(100);
+        handled = true;
+      }
+
+      if (handled) {
+        event.preventDefault();
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      quickSliderRect = quickSliderTrack.getBoundingClientRect();
+      applySliderPosition();
+    });
+
+    quickSliderPercent = multiplierToPercent(quickState.multiplier);
+    applySliderPosition();
+    updateQuickVisuals();
+  }
+
   const SLIDES = [
     {
       id: 'NA',


### PR DESCRIPTION
## Summary
- introduce a hero-adjacent "Quick Stripe payment lanes" section with tabs for each faith tradition
- add stylized slider, preset gift buttons, and animated checkout actions tied to each tradition's details
- implement JavaScript to update amounts, visuals, and controls based on the active lane and multiplier

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e39a846ef8832d865e36dbc8f3b7b9