### PR TITLE
Fix quick slider guard to avoid illegal return error

### DIFF
--- a/public/multifaith-giving-platform.html
+++ b/public/multifaith-giving-platform.html
@@ -2213,276 +2213,274 @@
     const quickGenerateLabel = quickGenerateBtn ? quickGenerateBtn.querySelector('span') : null;
     const quickShareLabel = quickShareBtn ? quickShareBtn.querySelector('span') : null;
 
-    if (!quickSliderTrack || !quickSliderProgress || !quickSliderThumb || !quickMultiplierLabel || !quickTotal) {
-      return;
-    }
+    if (quickSliderTrack && quickSliderProgress && quickSliderThumb && quickMultiplierLabel && quickTotal) {
+      const QUICK_SLIDER_MIN = 0.75;
+      const QUICK_SLIDER_MAX = 2.5;
+      const QUICK_SLIDER_STEP = 0.01;
+      const QUICK_PERCENT_STEP = 3.5;
+      const QUICK_PERCENT_FINE = 1.5;
 
-    const QUICK_SLIDER_MIN = 0.75;
-    const QUICK_SLIDER_MAX = 2.5;
-    const QUICK_SLIDER_STEP = 0.01;
-    const QUICK_PERCENT_STEP = 3.5;
-    const QUICK_PERCENT_FINE = 1.5;
+      const amountFormatters = new Map();
 
-    const amountFormatters = new Map();
+      const quickState = {
+        faith: QUICK_FAITHS[0]?.key ?? null,
+        multiplier: 1,
+        selectedIndex: 0
+      };
 
-    const quickState = {
-      faith: QUICK_FAITHS[0]?.key ?? null,
-      multiplier: 1,
-      selectedIndex: 0
-    };
+      let quickSliderRect = quickSliderTrack.getBoundingClientRect();
+      let quickSliderPercent = 0;
+      let quickSliderDragging = false;
 
-    let quickSliderRect = quickSliderTrack.getBoundingClientRect();
-    let quickSliderPercent = 0;
-    let quickSliderDragging = false;
+      quickSliderTrack.setAttribute('aria-valuemin', String(Math.round(QUICK_SLIDER_MIN * 100)));
+      quickSliderTrack.setAttribute('aria-valuemax', String(Math.round(QUICK_SLIDER_MAX * 100)));
 
-    quickSliderTrack.setAttribute('aria-valuemin', String(Math.round(QUICK_SLIDER_MIN * 100)));
-    quickSliderTrack.setAttribute('aria-valuemax', String(Math.round(QUICK_SLIDER_MAX * 100)));
-
-    function formatAmount(value, currency, locale) {
-      const key = `${locale}-${currency}`;
-      if (!amountFormatters.has(key)) {
-        amountFormatters.set(
-          key,
-          new Intl.NumberFormat(locale, {
-            style: 'currency',
-            currency,
-            maximumFractionDigits: 0,
-            minimumFractionDigits: 0
-          })
-        );
-      }
-      return amountFormatters.get(key).format(Math.max(0, Math.round(value)));
-    }
-
-    function formatMultiplier(value) {
-      const fixed = value.toFixed(2);
-      return `${fixed.replace(/0+$/, '').replace(/\.$/, '')}×`;
-    }
-
-    function percentToMultiplier(percent) {
-      return QUICK_SLIDER_MIN + (Math.max(0, Math.min(100, percent)) / 100) * (QUICK_SLIDER_MAX - QUICK_SLIDER_MIN);
-    }
-
-    function multiplierToPercent(multiplier) {
-      const clamped = Math.max(QUICK_SLIDER_MIN, Math.min(QUICK_SLIDER_MAX, multiplier));
-      return ((clamped - QUICK_SLIDER_MIN) / (QUICK_SLIDER_MAX - QUICK_SLIDER_MIN)) * 100;
-    }
-
-    function applySliderPosition() {
-      quickSliderProgress.style.width = `${quickSliderPercent}%`;
-      quickSliderThumb.style.left = `${quickSliderPercent}%`;
-      const ariaValue = Math.round(quickState.multiplier * 100);
-      quickSliderTrack.setAttribute('aria-valuenow', String(ariaValue));
-      quickSliderTrack.setAttribute('aria-valuetext', `${quickState.multiplier.toFixed(2)} times base gift`);
-      quickMultiplierLabel.textContent = formatMultiplier(quickState.multiplier);
-    }
-
-    function updateQuickAmounts() {
-      const config = QUICK_FAITH_MAP.get(quickState.faith);
-      if (!config) return;
-
-      quickAmounts.forEach((button, index) => {
-        const amountConfig = config.amounts[index] ?? config.amounts[config.amounts.length - 1];
-        const scaled = Math.round(amountConfig.base * quickState.multiplier / 5) * 5;
-        button.dataset.index = String(index);
-        button.dataset.amountValue = String(Math.max(0, scaled));
-        const valueLabel = button.querySelector('strong');
-        const descLabel = button.querySelector('span');
-        if (valueLabel) {
-          valueLabel.textContent = formatAmount(scaled, config.currency, config.locale);
+      function formatAmount(value, currency, locale) {
+        const key = `${locale}-${currency}`;
+        if (!amountFormatters.has(key)) {
+          amountFormatters.set(
+            key,
+            new Intl.NumberFormat(locale, {
+              style: 'currency',
+              currency,
+              maximumFractionDigits: 0,
+              minimumFractionDigits: 0
+            })
+          );
         }
-        if (descLabel) {
-          descLabel.textContent = amountConfig.label;
+        return amountFormatters.get(key).format(Math.max(0, Math.round(value)));
+      }
+
+      function formatMultiplier(value) {
+        const fixed = value.toFixed(2);
+        return `${fixed.replace(/0+$/, '').replace(/\.$/, '')}×`;
+      }
+
+      function percentToMultiplier(percent) {
+        return QUICK_SLIDER_MIN + (Math.max(0, Math.min(100, percent)) / 100) * (QUICK_SLIDER_MAX - QUICK_SLIDER_MIN);
+      }
+
+      function multiplierToPercent(multiplier) {
+        const clamped = Math.max(QUICK_SLIDER_MIN, Math.min(QUICK_SLIDER_MAX, multiplier));
+        return ((clamped - QUICK_SLIDER_MIN) / (QUICK_SLIDER_MAX - QUICK_SLIDER_MIN)) * 100;
+      }
+
+      function applySliderPosition() {
+        quickSliderProgress.style.width = `${quickSliderPercent}%`;
+        quickSliderThumb.style.left = `${quickSliderPercent}%`;
+        const ariaValue = Math.round(quickState.multiplier * 100);
+        quickSliderTrack.setAttribute('aria-valuenow', String(ariaValue));
+        quickSliderTrack.setAttribute('aria-valuetext', `${quickState.multiplier.toFixed(2)} times base gift`);
+        quickMultiplierLabel.textContent = formatMultiplier(quickState.multiplier);
+      }
+
+      function updateQuickAmounts() {
+        const config = QUICK_FAITH_MAP.get(quickState.faith);
+        if (!config) return;
+
+        quickAmounts.forEach((button, index) => {
+          const amountConfig = config.amounts[index] ?? config.amounts[config.amounts.length - 1];
+          const scaled = Math.round(amountConfig.base * quickState.multiplier / 5) * 5;
+          button.dataset.index = String(index);
+          button.dataset.amountValue = String(Math.max(0, scaled));
+          const valueLabel = button.querySelector('strong');
+          const descLabel = button.querySelector('span');
+          if (valueLabel) {
+            valueLabel.textContent = formatAmount(scaled, config.currency, config.locale);
+          }
+          if (descLabel) {
+            descLabel.textContent = amountConfig.label;
+          }
+          button.classList.toggle('is-selected', index === quickState.selectedIndex);
+        });
+
+        const activeButton = quickAmounts[quickState.selectedIndex];
+        const activeAmount = activeButton ? Number(activeButton.dataset.amountValue ?? 0) : 0;
+        quickTotal.textContent = `${formatAmount(activeAmount, config.currency, config.locale)} ready for checkout`;
+      }
+
+      function updateQuickVisuals() {
+        const config = QUICK_FAITH_MAP.get(quickState.faith);
+        if (!config) return;
+
+        if (quickFaithIcon) {
+          quickFaithIcon.innerHTML = config.icon;
         }
-        button.classList.toggle('is-selected', index === quickState.selectedIndex);
-      });
+        if (quickFaithTitle) {
+          quickFaithTitle.textContent = config.title;
+        }
+        if (quickFaithSubtitle) {
+          quickFaithSubtitle.textContent = config.subtitle;
+        }
+        if (quickTotalDetail) {
+          quickTotalDetail.textContent = config.detail;
+        }
+        if (quickGenerateLabel) {
+          quickGenerateLabel.textContent = config.ctaGenerate;
+        }
+        if (quickShareLabel) {
+          quickShareLabel.textContent = config.ctaShare;
+        }
 
-      const activeButton = quickAmounts[quickState.selectedIndex];
-      const activeAmount = activeButton ? Number(activeButton.dataset.amountValue ?? 0) : 0;
-      quickTotal.textContent = `${formatAmount(activeAmount, config.currency, config.locale)} ready for checkout`;
-    }
+        quickStripeCard.style.backgroundImage = config.cardGradient;
+        quickStripeCard.style.borderColor = config.borderColor;
+        quickSliderProgress.style.backgroundImage = config.gradient;
+        if (quickSummary) {
+          quickSummary.style.borderColor = config.summaryBorder;
+          quickSummary.style.boxShadow = config.summaryShadow;
+        }
 
-    function updateQuickVisuals() {
-      const config = QUICK_FAITH_MAP.get(quickState.faith);
-      if (!config) return;
+        quickTabs.forEach((tab) => {
+          const isActive = tab.dataset.faith === quickState.faith;
+          tab.classList.toggle('is-active', isActive);
+          tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+          tab.style.background = isActive ? config.gradient : 'transparent';
+          tab.style.color = isActive ? '#fff' : '';
+          tab.style.boxShadow = isActive ? config.shadow : '';
+        });
 
-      if (quickFaithIcon) {
-        quickFaithIcon.innerHTML = config.icon;
-      }
-      if (quickFaithTitle) {
-        quickFaithTitle.textContent = config.title;
-      }
-      if (quickFaithSubtitle) {
-        quickFaithSubtitle.textContent = config.subtitle;
-      }
-      if (quickTotalDetail) {
-        quickTotalDetail.textContent = config.detail;
-      }
-      if (quickGenerateLabel) {
-        quickGenerateLabel.textContent = config.ctaGenerate;
-      }
-      if (quickShareLabel) {
-        quickShareLabel.textContent = config.ctaShare;
+        updateQuickAmounts();
       }
 
-      quickStripeCard.style.backgroundImage = config.cardGradient;
-      quickStripeCard.style.borderColor = config.borderColor;
-      quickSliderProgress.style.backgroundImage = config.gradient;
-      if (quickSummary) {
-        quickSummary.style.borderColor = config.summaryBorder;
-        quickSummary.style.boxShadow = config.summaryShadow;
+      function setQuickFaith(key) {
+        if (!QUICK_FAITH_MAP.has(key)) return;
+        quickState.faith = key;
+        quickState.selectedIndex = 0;
+        updateQuickVisuals();
+      }
+
+      function setQuickPercent(percent) {
+        const clamped = Math.max(0, Math.min(100, percent));
+        quickSliderPercent = clamped;
+        const rawMultiplier = percentToMultiplier(clamped);
+        const roundedMultiplier = Math.round(rawMultiplier / QUICK_SLIDER_STEP) * QUICK_SLIDER_STEP;
+        quickState.multiplier = Math.max(QUICK_SLIDER_MIN, Math.min(QUICK_SLIDER_MAX, Number(roundedMultiplier.toFixed(2))));
+        applySliderPosition();
+        updateQuickAmounts();
+      }
+
+      function updateQuickFromClient(clientX) {
+        if (!quickSliderRect || quickSliderRect.width === 0) return;
+        const offset = clientX - quickSliderRect.left;
+        const percent = (offset / quickSliderRect.width) * 100;
+        setQuickPercent(percent);
+      }
+
+      function startSliderDrag(clientX) {
+        quickSliderDragging = true;
+        quickSliderRect = quickSliderTrack.getBoundingClientRect();
+        quickSliderThumb.classList.add('active');
+        updateQuickFromClient(clientX);
+      }
+
+      function stopSliderDrag() {
+        if (!quickSliderDragging) return;
+        quickSliderDragging = false;
+        quickSliderThumb.classList.remove('active');
       }
 
       quickTabs.forEach((tab) => {
-        const isActive = tab.dataset.faith === quickState.faith;
-        tab.classList.toggle('is-active', isActive);
-        tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
-        tab.style.background = isActive ? config.gradient : 'transparent';
-        tab.style.color = isActive ? '#fff' : '';
-        tab.style.boxShadow = isActive ? config.shadow : '';
+        tab.addEventListener('click', () => {
+          setQuickFaith(tab.dataset.faith);
+        });
       });
 
-      updateQuickAmounts();
-    }
+      quickAmounts.forEach((button) => {
+        button.addEventListener('click', () => {
+          const index = Number(button.dataset.index ?? 0);
+          quickState.selectedIndex = index;
+          updateQuickAmounts();
+        });
+      });
 
-    function setQuickFaith(key) {
-      if (!QUICK_FAITH_MAP.has(key)) return;
-      quickState.faith = key;
-      quickState.selectedIndex = 0;
+      quickSliderThumb.addEventListener('mousedown', (event) => {
+        event.preventDefault();
+        startSliderDrag(event.clientX);
+      });
+
+      quickSliderTrack.addEventListener('mousedown', (event) => {
+        event.preventDefault();
+        startSliderDrag(event.clientX);
+      });
+
+      document.addEventListener('mousemove', (event) => {
+        if (!quickSliderDragging) return;
+        updateQuickFromClient(event.clientX);
+      });
+
+      document.addEventListener('mouseup', stopSliderDrag);
+
+      quickSliderThumb.addEventListener(
+        'touchstart',
+        (event) => {
+          event.preventDefault();
+          const touch = event.touches[0];
+          if (touch) {
+            startSliderDrag(touch.clientX);
+          }
+        },
+        { passive: false }
+      );
+
+      quickSliderTrack.addEventListener(
+        'touchstart',
+        (event) => {
+          const touch = event.touches[0];
+          if (touch) {
+            startSliderDrag(touch.clientX);
+          }
+        },
+        { passive: true }
+      );
+
+      document.addEventListener(
+        'touchmove',
+        (event) => {
+          if (!quickSliderDragging) return;
+          const touch = event.touches[0];
+          if (touch) {
+            event.preventDefault();
+            updateQuickFromClient(touch.clientX);
+          }
+        },
+        { passive: false }
+      );
+
+      document.addEventListener('touchend', stopSliderDrag);
+      document.addEventListener('touchcancel', stopSliderDrag);
+
+      quickSliderTrack.addEventListener('keydown', (event) => {
+        let handled = false;
+        if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+          const step = event.shiftKey ? QUICK_PERCENT_FINE : QUICK_PERCENT_STEP;
+          setQuickPercent(quickSliderPercent + step);
+          handled = true;
+        } else if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+          const step = event.shiftKey ? QUICK_PERCENT_FINE : QUICK_PERCENT_STEP;
+          setQuickPercent(quickSliderPercent - step);
+          handled = true;
+        } else if (event.key === 'Home') {
+          setQuickPercent(0);
+          handled = true;
+        } else if (event.key === 'End') {
+          setQuickPercent(100);
+          handled = true;
+        }
+
+        if (handled) {
+          event.preventDefault();
+        }
+      });
+
+      window.addEventListener('resize', () => {
+        quickSliderRect = quickSliderTrack.getBoundingClientRect();
+        applySliderPosition();
+      });
+
+      quickSliderPercent = multiplierToPercent(quickState.multiplier);
+      applySliderPosition();
       updateQuickVisuals();
     }
-
-    function setQuickPercent(percent) {
-      const clamped = Math.max(0, Math.min(100, percent));
-      quickSliderPercent = clamped;
-      const rawMultiplier = percentToMultiplier(clamped);
-      const roundedMultiplier = Math.round(rawMultiplier / QUICK_SLIDER_STEP) * QUICK_SLIDER_STEP;
-      quickState.multiplier = Math.max(QUICK_SLIDER_MIN, Math.min(QUICK_SLIDER_MAX, Number(roundedMultiplier.toFixed(2))));
-      applySliderPosition();
-      updateQuickAmounts();
-    }
-
-    function updateQuickFromClient(clientX) {
-      if (!quickSliderRect || quickSliderRect.width === 0) return;
-      const offset = clientX - quickSliderRect.left;
-      const percent = (offset / quickSliderRect.width) * 100;
-      setQuickPercent(percent);
-    }
-
-    function startSliderDrag(clientX) {
-      quickSliderDragging = true;
-      quickSliderRect = quickSliderTrack.getBoundingClientRect();
-      quickSliderThumb.classList.add('active');
-      updateQuickFromClient(clientX);
-    }
-
-    function stopSliderDrag() {
-      if (!quickSliderDragging) return;
-      quickSliderDragging = false;
-      quickSliderThumb.classList.remove('active');
-    }
-
-    quickTabs.forEach((tab) => {
-      tab.addEventListener('click', () => {
-        setQuickFaith(tab.dataset.faith);
-      });
-    });
-
-    quickAmounts.forEach((button) => {
-      button.addEventListener('click', () => {
-        const index = Number(button.dataset.index ?? 0);
-        quickState.selectedIndex = index;
-        updateQuickAmounts();
-      });
-    });
-
-    quickSliderThumb.addEventListener('mousedown', (event) => {
-      event.preventDefault();
-      startSliderDrag(event.clientX);
-    });
-
-    quickSliderTrack.addEventListener('mousedown', (event) => {
-      event.preventDefault();
-      startSliderDrag(event.clientX);
-    });
-
-    document.addEventListener('mousemove', (event) => {
-      if (!quickSliderDragging) return;
-      updateQuickFromClient(event.clientX);
-    });
-
-    document.addEventListener('mouseup', stopSliderDrag);
-
-    quickSliderThumb.addEventListener(
-      'touchstart',
-      (event) => {
-        event.preventDefault();
-        const touch = event.touches[0];
-        if (touch) {
-          startSliderDrag(touch.clientX);
-        }
-      },
-      { passive: false }
-    );
-
-    quickSliderTrack.addEventListener(
-      'touchstart',
-      (event) => {
-        const touch = event.touches[0];
-        if (touch) {
-          startSliderDrag(touch.clientX);
-        }
-      },
-      { passive: true }
-    );
-
-    document.addEventListener(
-      'touchmove',
-      (event) => {
-        if (!quickSliderDragging) return;
-        const touch = event.touches[0];
-        if (touch) {
-          event.preventDefault();
-          updateQuickFromClient(touch.clientX);
-        }
-      },
-      { passive: false }
-    );
-
-    document.addEventListener('touchend', stopSliderDrag);
-    document.addEventListener('touchcancel', stopSliderDrag);
-
-    quickSliderTrack.addEventListener('keydown', (event) => {
-      let handled = false;
-      if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
-        const step = event.shiftKey ? QUICK_PERCENT_FINE : QUICK_PERCENT_STEP;
-        setQuickPercent(quickSliderPercent + step);
-        handled = true;
-      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
-        const step = event.shiftKey ? QUICK_PERCENT_FINE : QUICK_PERCENT_STEP;
-        setQuickPercent(quickSliderPercent - step);
-        handled = true;
-      } else if (event.key === 'Home') {
-        setQuickPercent(0);
-        handled = true;
-      } else if (event.key === 'End') {
-        setQuickPercent(100);
-        handled = true;
-      }
-
-      if (handled) {
-        event.preventDefault();
-      }
-    });
-
-    window.addEventListener('resize', () => {
-      quickSliderRect = quickSliderTrack.getBoundingClientRect();
-      applySliderPosition();
-    });
-
-    quickSliderPercent = multiplierToPercent(quickState.multiplier);
-    applySliderPosition();
-    updateQuickVisuals();
   }
 
   const SLIDES = [


### PR DESCRIPTION
## Summary
- wrap the quick donation slider logic in a guard that only runs when required DOM elements exist
- prevent illegal top-level return statements that caused runtime syntax errors in the giving platform script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3a07a2174832d999f9428fd9fed5b