### PR TITLE
Fix early metrics lookup state initialization

### DIFF
--- a/public/multifaith-giving-platform.html
+++ b/public/multifaith-giving-platform.html
@@ -2377,6 +2377,22 @@
     }
   ];
 
+  const state = {
+    orgs: [],
+    campaignsByOrg: new Map(),
+    campaignFetchAttempts: new Set(),
+    communityCampaigns: [],
+    slideIndex: 0,
+    autoTimer: null,
+    slideImages: new Map(),
+    lastSlideImage: new Map(),
+    hasRenderedInitialSlide: false,
+    isTransitioning: false,
+    preloadedSlideId: null,
+    metricsByFaith: new Map(),
+    metricsUpdatedAt: null
+  };
+
   const QUICK_FAITH_MAP = new Map(QUICK_FAITHS.map((faith) => [faith.key, faith]));
 
   const STRIPE_MAX_AMOUNT = 999999999999;
@@ -3213,22 +3229,6 @@
   ]);
 
   const MAX_FAITH_SYMBOL_TILT = 10;
-
-  const state = {
-    orgs: [],
-    campaignsByOrg: new Map(),
-    campaignFetchAttempts: new Set(),
-    communityCampaigns: [],
-    slideIndex: 0,
-    autoTimer: null,
-    slideImages: new Map(),
-    lastSlideImage: new Map(),
-    hasRenderedInitialSlide: false,
-    isTransitioning: false,
-    preloadedSlideId: null,
-    metricsByFaith: new Map(),
-    metricsUpdatedAt: null
-  };
 
   const SECTOR_TITLE_LOOKUP = new Map(SECTORS.map(sector => [sector.value, sector.title]));
 


### PR DESCRIPTION
## Summary
- move the shared UI state initialization ahead of the quick checkout setup so it is available during initial render

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3bdfd88e4832da542e2dab6367035