### PR TITLE
Improve mobile layout for multifaith platform

### DIFF
--- a/public/multifaith-giving-platform.html
+++ b/public/multifaith-giving-platform.html
@@ -1881,6 +1881,235 @@
         display: none;
       }
     }
+
+    @media screen and (max-width: 430px) {
+      body {
+        font-size: 17px;
+        line-height: 1.65;
+        touch-action: manipulation;
+      }
+
+      header {
+        border-bottom-width: 0;
+      }
+
+      .nav {
+        padding: 14px 16px;
+        gap: 12px;
+      }
+
+      .brand {
+        gap: 8px;
+      }
+
+      .brand strong {
+        font-size: 20px;
+      }
+
+      .brand span {
+        font-size: 13px;
+      }
+
+      main {
+        padding: 18px 16px 64px;
+        gap: 36px;
+      }
+
+      .inline-actions {
+        gap: 12px;
+      }
+
+      .inline-actions .btn,
+      .nav .btn,
+      .btn {
+        font-size: 16px;
+        padding: 13px 16px;
+      }
+
+      .hero {
+        gap: 16px;
+        text-align: left;
+      }
+
+      .hero h1 {
+        font-size: clamp(30px, 9vw, 40px);
+      }
+
+      .hero p {
+        font-size: 17px;
+        margin-bottom: 18px;
+      }
+
+      .hero-media {
+        margin: 0 -4px;
+        border-radius: 20px;
+        min-height: 210px;
+      }
+
+      .hero-list {
+        gap: 10px;
+      }
+
+      .hero-list li {
+        font-size: 16px;
+        padding: 12px 14px;
+      }
+
+      .section-head {
+        gap: 14px;
+      }
+
+      .region-slider {
+        margin-inline: -2px;
+        border-radius: 20px;
+      }
+
+      .region-slide {
+        padding: 18px;
+        gap: 16px;
+      }
+
+      .region-meta h3 {
+        font-size: 21px;
+      }
+
+      .region-meta p {
+        font-size: 16px;
+      }
+
+      .region-currencies {
+        gap: 12px;
+      }
+
+      .region-currency-list {
+        gap: 10px;
+      }
+
+      .region-currency-item {
+        flex: 1 1 calc(50% - 10px);
+        min-width: 0;
+        padding: 12px 14px;
+      }
+
+      .region-currency-image {
+        width: 60px;
+        height: 42px;
+      }
+
+      .region-tags {
+        flex-direction: column;
+        gap: 12px;
+        align-items: stretch;
+      }
+
+      .region-tag {
+        width: 100%;
+        height: auto;
+        border-radius: 20px;
+        padding: 16px 18px;
+        flex-direction: row;
+        justify-content: flex-start;
+        text-align: left;
+        gap: 12px;
+      }
+
+      .region-tag::after {
+        inset: 14%;
+      }
+
+      .region-tag-label {
+        font-size: 14px;
+      }
+
+      .region-tag-metric {
+        align-self: flex-start;
+        font-size: 12px;
+      }
+
+      .sector-grid,
+      .community-grid {
+        gap: 20px;
+      }
+
+      .quick-stripe-card {
+        padding: 22px 18px;
+        border-radius: 20px;
+        gap: 22px;
+      }
+
+      .quick-tabs {
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .quick-tabs .manage-tab {
+        width: 100%;
+      }
+
+      .quick-faith-intro {
+        gap: 12px;
+        align-items: flex-start;
+      }
+
+      .quick-faith-heading {
+        font-size: 18px;
+        align-items: flex-start;
+        gap: 10px;
+      }
+
+      .quick-faith-heading span {
+        font-size: 14px;
+      }
+
+      .quick-faith-icon {
+        width: 52px;
+        height: 52px;
+      }
+
+      .quick-summary {
+        padding: 16px;
+        gap: 14px;
+      }
+
+      .quick-summary strong {
+        font-size: 17px;
+      }
+
+      .quick-metrics {
+        gap: 10px;
+      }
+
+      .quick-actions {
+        width: 100%;
+        justify-content: stretch;
+      }
+
+      .quick-actions .btn,
+      .form-actions .btn {
+        width: 100%;
+      }
+
+      .manage-tabs {
+        flex-direction: column;
+      }
+
+      .manage-tab {
+        width: 100%;
+      }
+
+      .form-card {
+        padding: 20px 18px;
+      }
+
+      .form-row {
+        gap: 14px;
+      }
+
+      footer {
+        padding: 30px 0 50px;
+        font-size: 13px;
+      }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add a dedicated 430px media query to tune spacing, typography, and stacking for the multifaith giving page on small screens
- ensure key modules (hero, region slider, quick actions, and forms) expand to the full width and remain readable without horizontal scrolling

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68e3e38c468c832d998e2a468cc331d0