### PR TITLE
Fix quick summary overflow on mobile

### DIFF
--- a/public/multifaith-giving-platform.html
+++ b/public/multifaith-giving-platform.html
@@ -1249,6 +1249,10 @@
       border: 1px solid rgba(31, 41, 55, 0.08);
     }
 
+    .quick-summary > * {
+      min-width: 0;
+    }
+
     .quick-summary strong {
       font-size: 18px;
     }


### PR DESCRIPTION
## Summary
- allow the quick summary content to shrink within its flex container to prevent mobile overflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3f4e8c790832db8fd4485254ee2a3