### PR TITLE
Improve mobile Quick Stripe layout

### DIFF
--- a/public/multifaith-giving-platform.html
+++ b/public/multifaith-giving-platform.html
@@ -2388,6 +2388,55 @@
         margin-right: auto;
       }
     }
+
+    @media (max-width: 640px) {
+      .quick-stripe-card {
+        padding: 18px 14px;
+        border-radius: 18px;
+        gap: 18px;
+      }
+
+      .quick-tabs {
+        padding: 6px 4px;
+        gap: 8px;
+      }
+
+      .quick-panel {
+        padding: 18px;
+      }
+
+      .quick-faith-intro {
+        gap: 10px 14px;
+        align-items: flex-start;
+      }
+
+      .quick-summary {
+        display: grid;
+        gap: 16px;
+      }
+
+      .quick-summary > * {
+        width: 100%;
+      }
+
+      .quick-metrics {
+        grid-template-columns: 1fr;
+      }
+
+      .quick-actions {
+        display: grid;
+        gap: 10px;
+        width: 100%;
+      }
+
+      .quick-actions .btn {
+        width: 100%;
+      }
+
+      .quick-status-block {
+        gap: 12px;
+      }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add a dedicated 640px breakpoint that tightens padding around the Quick Stripe card
- refactor the Quick Stripe summary, metrics, and action blocks into a stacked grid on small screens so the checkout buttons stay visible
- ensure the mobile controls fill the available width for easier tapping

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3fad2d1ec832d97b316f6e4372415